### PR TITLE
20221117 add hotfix select file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	# Pull and build clvm_tools_rs
 	git clone https://github.com/Chia-Network/clvm_tools_rs
-	cd clvm_tools_rs/wasm && git checkout 20220805-language-server && wasm-pack build --target=nodejs && cp pkg/* ../../runner/build
+	cd clvm_tools_rs/wasm && git checkout 20221117-add-code-action-for-unknown-include && wasm-pack build --target=nodejs && cp pkg/* ../../runner/build
 	# Build the runner
 	cd runner && npm install && npm run build
 	# Remove the subdir post-build

--- a/package.json
+++ b/package.json
@@ -43,11 +43,17 @@
                 "title": "Chialisp",
                 "properties": {
                     "chialisp.stderrLogPath": {
-                        "type":"string",
-                        "default":"",
-                        "description":"filename for stderr log for lsp"
+                        "type": "string",
+                        "default": "",
+                        "description": "filename for stderr log for lsp"
                     }
                 }
+            }
+        ],
+        "commands": [
+            {"command": "chialisp.locateIncludePath",
+             "title": "Locate include file",
+             "category": "Chialisp"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,15 +50,9 @@ async function activateServer(context: vscode.ExtensionContext) {
         debugArgs = [];
     }
 
-    // Register associations
-    const exeOptions: ExecutableOptions = {
-        cwd: ourExtensionPath,
-        env: { ... process.env }
-    };
-
     const serverOptions: ServerOptions = {
-        run: {command: serverExecutable, transport: TransportKind.stdio, args: serverArgs, options: exeOptions},
-        debug: {command: serverExecutable, transport: TransportKind.stdio, args: debugArgs, options: exeOptions}
+        run: {module: path.join(ourExtensionPath, "runner/build/runner.js")},
+        debug: {module: path.join(ourExtensionPath, "runner/build/runner.js")}
     };
 
     const fileToExaminePattern = '**/*';


### PR DESCRIPTION
Change runtime from assumed-installed node to NodeModule type.
Add a hotfix that allows the user to browse for a missing include and automatically creates/adds its path to chialisp.json.
Built with new current language server including hotfix support.