### PR TITLE
Bump to 0.2.0 due to microsoft advice about version numbering for int…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "icon": "images/chialisp.png",
     "description": "A Rust LSP client for Chialisp",
     "publisher": "ChiaNetwork",
-    "version": "0.0.1",
+    "version": "0.2.0",
     "engines": {
         "vscode": "^1.70.0"
     },


### PR DESCRIPTION
…erleaving release and pre-release versions