### PR TITLE
date fixer which sets the file dates 12 hours in the past in the vsix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           echo "VSIX_FILE=$(ls -- *.vsix)" >>$GITHUB_OUTPUT
       - name: Fix zip file dates
         run: |
-          python datefilx.py *.vsix
+          python datefix.py *.vsix
       - name: Run headless test
         run: |
           sudo apt update

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
         run: |
           ./node_modules/.bin/vsce package --no-yarn
           echo "VSIX_FILE=$(ls -- *.vsix)" >>$GITHUB_OUTPUT
+      - name: Fix zip file dates
+        run: |
+          python datefilx.py *.vsix
       - name: Run headless test
         run: |
           sudo apt update

--- a/datefix.py
+++ b/datefix.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import time
+import zipfile
+
+twelve_hours = 12 * 60 * 60
+
+def fixdates(fname):
+	current_time = time.gmtime(time.time() - twelve_hours)
+	target_name = fname + '.tmp'
+
+	with zipfile.ZipFile(fname, 'r') as zf:
+		with zipfile.ZipFile(target_name, 'w') as zf_out:
+			for member in zf.namelist():
+				zi = zf.getinfo(member)
+				data = zf.read(member)
+				zi.date_time = (current_time.tm_year, current_time.tm_mon, current_time.tm_mday, current_time.tm_hour, current_time.tm_min, current_time.tm_sec)
+				zf_out.writestr(zi, data)
+	
+	os.rename(target_name, fname)
+
+if __name__ == '__main__':
+	if len(sys.argv) < 2:
+		print('usage: datefix.py package.vsix')
+		sys.exit(1)
+
+	fixdates(sys.argv[1])


### PR DESCRIPTION
Adds a python program to go through the zip file and set the dates 12 hours earlier.  This is due to an error we see uploading the vsix to the code app store, which isn't thoroughly investigated yet, but this may tell us something about it.