### PR TITLE
Use ubuntu-22.04 instead of ubuntu-latest for workflows

### DIFF
--- a/.github/workflows/nightly-dev.yml
+++ b/.github/workflows/nightly-dev.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 name: Deploy Extension
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/wasm-test.yml
+++ b/.github/workflows/wasm-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
`libasound2` doesn't exist on Ubuntu 24 - for simplicity and consistency move the workflows to using Ubuntu 22.04 instead of Ubuntu-latest