### PR TITLE
Update to libasound2t64 for publish.yml and nightly-dev.yml

### DIFF
--- a/.github/workflows/nightly-dev.yml
+++ b/.github/workflows/nightly-dev.yml
@@ -71,7 +71,7 @@ jobs:
           DETECT_CHROMEDRIVER_VERSION: "true"
         run: |
           sudo apt update
-          sudo apt-get install -qy xvfb libnss3-dev libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libasound2
+          sudo apt-get install -qy xvfb libnss3-dev libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libasound2t64
           xvfb-run -a ./test/test.sh
       - name: Cleanup xvfb pidx
         if: env.SKIP != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run headless test
         run: |
           sudo apt update
-          sudo apt-get install -qy xvfb libnss3-dev libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libasound2
+          sudo apt-get install -qy xvfb libnss3-dev libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libasound2t64
           xvfb-run -a ./test/test.sh
 
       - name: Cleanup xvfb pidx


### PR DESCRIPTION
PR #110 missed a couple workflows - namely `publish.yml` and `nightly-dev.yml` - those also run (now) on `Ubuntu 24` (ubuntu-latest) and need to use the `libasound2t46` package.