### PR TITLE
Fix semtok helper matching for renamed exposing imports

### DIFF
--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -97,6 +97,26 @@ fn find_call_token(
     l: &Srcloc,
     name: &Vec<u8>,
 ) -> Option<(SemanticTokenSortable, Srcloc)> {
+    let find_helper_by_name = |helper_name: &[u8]| {
+        for f in frontend.helpers.iter() {
+            match f {
+                HelperForm::Defun(_inline, defun) => {
+                    if defun.name == helper_name {
+                        return Some((TK_FUNCTION_IDX, defun.nl.clone()));
+                    }
+                }
+                HelperForm::Defmacro(mac) => {
+                    if mac.name == helper_name {
+                        return Some((TK_MACRO_IDX, mac.nl.clone()));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        None
+    };
+
     for f in frontend.helpers.iter() {
         match f {
             HelperForm::Defun(_inline, defun) => {
@@ -120,6 +140,31 @@ fn find_call_token(
                 }
             }
             _ => {}
+        }
+    }
+
+    for f in frontend.helpers.iter() {
+        if let HelperForm::Defnsref(nsref) = f {
+            if let ModuleImportSpec::Exposing(_, exposed_names) = &nsref.specification {
+                for exposed in exposed_names.iter() {
+                    let exposed_name = exposed.alias.as_ref().unwrap_or(&exposed.name);
+                    if exposed_name != name {
+                        continue;
+                    }
+
+                    let imported_target = find_helper_by_name(&exposed.name);
+                    let (token_type, target_loc) =
+                        imported_target.unwrap_or((TK_FUNCTION_IDX, exposed.nl.clone()));
+                    return Some((
+                        SemanticTokenSortable {
+                            loc: l.clone(),
+                            token_type,
+                            token_mod: 0,
+                        },
+                        target_loc,
+                    ));
+                }
+            }
         }
     }
 
@@ -498,6 +543,9 @@ pub fn build_semantic_tokens(
                     }
                     ModuleImportSpec::Exposing(l, e) => {
                         for h in e.iter() {
+                            if h.alias.is_some() {
+                                continue;
+                            }
                             collected_tokens.push(SemanticTokenSortable {
                                 loc: h.nl.clone(),
                                 token_type: TK_VARIABLE_IDX,

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -2090,7 +2090,7 @@ fn test_sem_tok_for_module_style_reverse_function() {
             SemanticToken {
                 delta_line: 0,
                 delta_start: 7,
-                length: 10,
+                length: 11,
                 token_type: TK_VARIABLE_IDX,
                 token_modifiers_bitset: 0,
             },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update semantic token call classification to consider `import ... exposing (name as alias)` renames when resolving helper calls
- treat the exposed alias as the call-site name and map it back to the imported helper name when looking for function/macro definitions
- avoid emitting an extra variable semantic token for exposing entries that use `as` rename syntax (so token stream aligns with expected coloring)
- adjust the reverse module-style semantic token test expectation for import-name token length (`std.reverse`)

## Testing
- `cargo +stable test --manifest-path wasm/Cargo.toml test_sem_tok_for_module_style -- --nocapture`
- `cargo +stable test --manifest-path wasm/Cargo.toml test_sem_tok_for_module_style_reverse_function`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d982d301-3ec0-4e01-8eac-5e5cb0a25ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d982d301-3ec0-4e01-8eac-5e5cb0a25ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

