### PR TITLE
Track unresolved imports in LSP missing-include checks

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,5 @@ vsc-extension-quickstart.md
 runner/node_modules
 wasm/src
 wasm/target
+config
+workspace

--- a/debug/package-lock.json
+++ b/debug/package-lock.json
@@ -1632,9 +1632,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "5.1.0",

--- a/resources/tests/std/assert.clinc
+++ b/resources/tests/std/assert.clinc
@@ -1,0 +1,8 @@
+(defun assert_ (items)
+  (if (r items)
+    (qq (if (unquote (f items)) (unquote (assert_ (r items))) (x)))
+    (f items)
+    )
+  )
+
+(defmac assert items (assert_ items))

--- a/resources/tests/std/reverse.clinc
+++ b/resources/tests/std/reverse.clinc
@@ -1,0 +1,10 @@
+(defun reverse_inner (reversed rest)
+    (if rest
+        (reverse_inner (c (f rest) reversed) (r rest))
+        reversed
+    )
+)
+
+(defun reverse (vals)
+    (reverse_inner 0 vals)
+)

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -2517,9 +2517,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "5.1.0",

--- a/runner/src/index.js
+++ b/runner/src/index.js
@@ -6,7 +6,9 @@ import { StdinReader } from './stdin_reader.js';
 // clean 1:1 8-bit encoding.
 process.stdin.setEncoding('binary');
 
-const emptyWriteLog = (line) => { };
+const emptyWriteLog = (line) => {
+  fs.appendFileSync('/tmp/stderr.txt', line);
+};
 const log = {
 	write: emptyWriteLog
 };

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,13 +128,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.42.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8663dc7139234c60fccddc0babeb5b0a0a55b14943d74c73ac8aad130c5b79e3"
+checksum = "4f02cbfd038d9050d45edbe8f38e09391c73479c0cca5b37925daf48c4d4fcd4"
 dependencies = [
  "blst",
- "chia-sha2 0.42.0",
- "chia-traits 0.42.0",
+ "chia-sha2 0.36.1",
+ "chia-traits 0.36.1",
  "hex",
  "hkdf",
  "linked-hash-map",
@@ -147,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.42.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6636ca8bba852fc516eacf01b2c3964b6b290359e7d1e89b950e6754e2a1082"
+checksum = "0934b0d6b878f29ba6c958e56e4b7158f9e687c200ffdca141dbc408a5cce42e"
 dependencies = [
  "sha2",
 ]
@@ -167,12 +173,12 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.42.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3517dcf2b743672c78339ef8d222fd4493ae48741c35dd5ffb2d9dba90417115"
+checksum = "1f4922b447b2d8418213948af1a448c3ca7b84e149b51b2c87a2e00e80bb19b0"
 dependencies = [
- "chia-sha2 0.42.0",
- "chia_streamable_macro 0.42.0",
+ "chia-sha2 0.36.1",
+ "chia_streamable_macro 0.36.1",
  "thiserror",
 ]
 
@@ -190,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.42.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f85fb91e5ddba8003c4c4ad13c7914b1ff733d92136805c6566de227321d49"
+checksum = "2b60cefc5fe39f695816d42a327cbefad3d6d6a8ecadad1b58d7507067c25da8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -203,11 +209,12 @@ dependencies = [
 [[package]]
 name = "chialisp"
 version = "0.4.3"
-source = "git+https://github.com/Chia-Network/chialisp?rev=bb4fe971b1d4d444fbc110483987673fe6337faa#bb4fe971b1d4d444fbc110483987673fe6337faa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d6fb2e2ebe04084731145d5840f0224a29698c69c339f755e2a139374df4ff"
 dependencies = [
  "binascii",
- "chia-bls 0.42.0",
- "clvmr",
+ "chia-bls 0.36.1",
+ "clvmr 0.16.2",
  "do-notation",
  "getrandom 0.2.9",
  "hashlink",
@@ -234,7 +241,7 @@ name = "clvm_tools_lsp"
 version = "1.2.4"
 dependencies = [
  "chialisp",
- "clvmr",
+ "clvmr 0.17.5",
  "debug_types",
  "getrandom 0.2.9",
  "indoc 1.0.9",
@@ -265,6 +272,32 @@ dependencies = [
  "hex-literal",
  "k256",
  "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "rand",
+ "sha1",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "clvmr"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b333963b083468df9a15602fcc3a24fa3f8c3964569fb9d2415ac70c0820e9"
+dependencies = [
+ "bitflags 2.11.1",
+ "bitvec",
+ "bumpalo",
+ "chia-bls 0.36.1",
+ "chia-sha2 0.36.1",
+ "hex",
+ "hex-literal",
+ "k256",
+ "lazy_static",
+ "malachite-bigint",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -380,6 +413,12 @@ dependencies = [
  "signature",
  "spki",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -609,6 +648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +754,43 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-bigint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fcd6e504ffc67db2b3c6d5e90e08054646e2b04f42115a5460bf1c1e37d3bc"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+ "num-integer",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
+dependencies = [
+ "itertools",
+ "libm",
+ "malachite-base",
+ "wide",
 ]
 
 [[package]]
@@ -819,6 +910,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -979,7 +1076,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -994,9 +1091,18 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -1402,6 +1508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,7 +1622,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
@@ -122,13 +122,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.30.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a74b1699d07115c71c081826608e3fb73f2aed94f9060fa09d074a95cfc93ab"
+checksum = "8663dc7139234c60fccddc0babeb5b0a0a55b14943d74c73ac8aad130c5b79e3"
 dependencies = [
  "blst",
- "chia-sha2 0.30.0",
- "chia-traits 0.30.0",
+ "chia-sha2 0.42.0",
+ "chia-traits 0.42.0",
  "hex",
  "hkdf",
  "linked-hash-map",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.30.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114775b95f24b296047dc9c91e43834aa651c7c25bb2bbae05d23d79c9c777b"
+checksum = "d6636ca8bba852fc516eacf01b2c3964b6b290359e7d1e89b950e6754e2a1082"
 dependencies = [
  "sha2",
 ]
@@ -167,12 +167,12 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.30.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143545b13658929fce2e770a499fd4755f04a4d5f6459dc76a79068ae192a8c5"
+checksum = "3517dcf2b743672c78339ef8d222fd4493ae48741c35dd5ffb2d9dba90417115"
 dependencies = [
- "chia-sha2 0.30.0",
- "chia_streamable_macro 0.30.0",
+ "chia-sha2 0.42.0",
+ "chia_streamable_macro 0.42.0",
  "thiserror",
 ]
 
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.30.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bd4fbc3f05375c267ee4cb2a4a1bf8125fa0d817e57d7b141993c35994c751"
+checksum = "41f85fb91e5ddba8003c4c4ad13c7914b1ff733d92136805c6566de227321d49"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -202,12 +202,11 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5f2217b8d1a7575ca7889a2f655294c02607cabfe9029e2ed8de13104edeca"
+version = "0.4.3"
+source = "git+https://github.com/Chia-Network/chialisp?rev=bb4fe971b1d4d444fbc110483987673fe6337faa#bb4fe971b1d4d444fbc110483987673fe6337faa"
 dependencies = [
  "binascii",
- "chia-bls 0.30.0",
+ "chia-bls 0.42.0",
  "clvmr",
  "do-notation",
  "getrandom 0.2.9",
@@ -424,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -445,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -525,20 +524,20 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -656,9 +655,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linked-hash-map"
@@ -668,9 +667,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -711,9 +710,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -937,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -976,15 +975,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1147,15 +1146,15 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1248,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "url"
@@ -1408,8 +1407,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1418,6 +1423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1506,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -93,12 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,13 +122,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f02cbfd038d9050d45edbe8f38e09391c73479c0cca5b37925daf48c4d4fcd4"
+checksum = "8663dc7139234c60fccddc0babeb5b0a0a55b14943d74c73ac8aad130c5b79e3"
 dependencies = [
  "blst",
- "chia-sha2 0.36.1",
- "chia-traits 0.36.1",
+ "chia-sha2 0.42.0",
+ "chia-traits 0.42.0",
  "hex",
  "hkdf",
  "linked-hash-map",
@@ -153,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0934b0d6b878f29ba6c958e56e4b7158f9e687c200ffdca141dbc408a5cce42e"
+checksum = "d6636ca8bba852fc516eacf01b2c3964b6b290359e7d1e89b950e6754e2a1082"
 dependencies = [
  "sha2",
 ]
@@ -173,12 +167,12 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4922b447b2d8418213948af1a448c3ca7b84e149b51b2c87a2e00e80bb19b0"
+checksum = "3517dcf2b743672c78339ef8d222fd4493ae48741c35dd5ffb2d9dba90417115"
 dependencies = [
- "chia-sha2 0.36.1",
- "chia_streamable_macro 0.36.1",
+ "chia-sha2 0.42.0",
+ "chia_streamable_macro 0.42.0",
  "thiserror",
 ]
 
@@ -196,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b60cefc5fe39f695816d42a327cbefad3d6d6a8ecadad1b58d7507067c25da8"
+checksum = "41f85fb91e5ddba8003c4c4ad13c7914b1ff733d92136805c6566de227321d49"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -209,12 +203,11 @@ dependencies = [
 [[package]]
 name = "chialisp"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d6fb2e2ebe04084731145d5840f0224a29698c69c339f755e2a139374df4ff"
+source = "git+https://github.com/Chia-Network/chialisp?rev=bb4fe971b1d4d444fbc110483987673fe6337faa#bb4fe971b1d4d444fbc110483987673fe6337faa"
 dependencies = [
  "binascii",
- "chia-bls 0.36.1",
- "clvmr 0.16.2",
+ "chia-bls 0.42.0",
+ "clvmr",
  "do-notation",
  "getrandom 0.2.9",
  "hashlink",
@@ -241,7 +234,7 @@ name = "clvm_tools_lsp"
 version = "1.2.4"
 dependencies = [
  "chialisp",
- "clvmr 0.17.5",
+ "clvmr",
  "debug_types",
  "getrandom 0.2.9",
  "indoc 1.0.9",
@@ -272,32 +265,6 @@ dependencies = [
  "hex-literal",
  "k256",
  "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "p256",
- "rand",
- "sha1",
- "sha3",
- "thiserror",
-]
-
-[[package]]
-name = "clvmr"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b333963b083468df9a15602fcc3a24fa3f8c3964569fb9d2415ac70c0820e9"
-dependencies = [
- "bitflags 2.11.1",
- "bitvec",
- "bumpalo",
- "chia-bls 0.36.1",
- "chia-sha2 0.36.1",
- "hex",
- "hex-literal",
- "k256",
- "lazy_static",
- "malachite-bigint",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -413,12 +380,6 @@ dependencies = [
  "signature",
  "spki",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -648,15 +609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,12 +660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,43 +700,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
-]
-
-[[package]]
-name = "malachite-base"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
-dependencies = [
- "hashbrown 0.16.1",
- "itertools",
- "libm",
- "ryu",
-]
-
-[[package]]
-name = "malachite-bigint"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fcd6e504ffc67db2b3c6d5e90e08054646e2b04f42115a5460bf1c1e37d3bc"
-dependencies = [
- "malachite-base",
- "malachite-nz",
- "num-integer",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "malachite-nz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
-dependencies = [
- "itertools",
- "libm",
- "malachite-base",
- "wide",
 ]
 
 [[package]]
@@ -910,12 +819,6 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1094,15 +997,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "safe_arch"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "same-file"
@@ -1505,16 +1399,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wide"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/mod.rs"
 wasm-opt = false # ["-Oz", "--enable-mutable-globals", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
 
 [dependencies]
-chialisp = "0.4.3"
-clvmr = "0.17.5"
+chialisp = { git = "https://github.com/Chia-Network/chialisp", rev = "bb4fe971b1d4d444fbc110483987673fe6337faa" }
+clvmr = "0.16.0"
 wasm-bindgen = "=0.2.100"
 wasm-bindgen-test = "=0.3.50"
 js-sys = "0.3.77"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -16,18 +16,21 @@ name = "clvm_tools_lsp"
 crate-type = ["cdylib"]
 path = "src/mod.rs"
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false # ["-Oz", "--enable-mutable-globals", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
+
 [dependencies]
-chialisp = "=0.4.1"
+chialisp = { git = "https://github.com/Chia-Network/chialisp", rev = "bb4fe971b1d4d444fbc110483987673fe6337faa" }
 clvmr = "0.16.0"
 wasm-bindgen = "=0.2.100"
 wasm-bindgen-test = "=0.3.50"
-js-sys = "0.3.60"
+js-sys = "0.3.77"
 serde_json = "1.0"
 serde = "1.0.142"
 lsp-server = "0.6.0"
 lsp-types = "0.93.0"
 lazy_static = "1.4.0"
-regex = "1.6.0"
+regex = "1.12.3"
 url = "2.3.1"
 percent-encoding = "2.2.0"
 indoc = "1.0"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/mod.rs"
 wasm-opt = false # ["-Oz", "--enable-mutable-globals", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
 
 [dependencies]
-chialisp = { git = "https://github.com/Chia-Network/chialisp", rev = "bb4fe971b1d4d444fbc110483987673fe6337faa" }
-clvmr = "0.16.0"
+chialisp = "0.4.3"
+clvmr = "0.17.5"
 wasm-bindgen = "=0.2.100"
 wasm-bindgen-test = "=0.3.50"
 js-sys = "0.3.77"

--- a/wasm/src/dbg/compopts.rs
+++ b/wasm/src/dbg/compopts.rs
@@ -9,11 +9,14 @@ use crate::lsp::patch::{compute_comment_lines, get_bytes, split_text};
 use crate::lsp::types::DocData;
 use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 use chialisp::compiler::compiler::{compile_pre_forms, STANDARD_MACROS};
-use chialisp::compiler::comptypes::{CompileErr, CompilerOpts, HasCompilerOptsDelegation};
+use chialisp::compiler::comptypes::{
+    CompileErr, CompilerOpts, CompilerOutput, HasCompilerOptsDelegation,
+};
 use chialisp::compiler::dialect::{DialectDescription, KNOWN_DIALECTS};
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
+use chialisp::compiler::BasicCompileContext;
 use chialisp::compiler::CompileContextWrapper;
 
 #[derive(Clone)]
@@ -62,19 +65,12 @@ impl HasCompilerOptsDelegation for DbgCompilerOpts {
 
     fn override_compile_program(
         &self,
-        allocator: &mut Allocator,
-        runner: Rc<dyn TRunProgram>,
+        context: &mut BasicCompileContext,
         sexp: Rc<SExp>,
-        symbol_table: &mut HashMap<String, String>,
-    ) -> Result<SExp, CompileErr> {
+    ) -> Result<CompilerOutput, CompileErr> {
         let me = Rc::new(self.clone());
-        let mut context_wrapper = CompileContextWrapper::new(
-            allocator,
-            runner,
-            symbol_table,
-            get_optimizer(&Srcloc::start(&self.filename()), me.clone())?,
-        );
-        compile_pre_forms(&mut context_wrapper.context, me, &[sexp])
+        let runner = context.runner.clone();
+        compile_pre_forms(context, me, &[sexp])
     }
 }
 

--- a/wasm/src/dbg/handler.rs
+++ b/wasm/src/dbg/handler.rs
@@ -1,35 +1,50 @@
 use serde::Deserialize;
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::io::BufRead;
 use std::mem::swap;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use debug_types::events::{ContinuedEvent, Event, EventBody, StoppedEvent, StoppedReason};
-use debug_types::requests::{InitializeRequestArguments, RequestCommand};
+use debug_types::requests::{
+    InitializeRequestArguments, LaunchRequestArguments, RequestCommand, SourceArguments,
+};
 use debug_types::responses::{
     InitializeResponse, Response, ResponseBody, ScopesResponse, SetBreakpointsResponse,
-    SetExceptionBreakpointsResponse, StackTraceResponse, ThreadsResponse, VariablesResponse,
+    SetExceptionBreakpointsResponse, SourceResponse, StackTraceResponse, ThreadsResponse,
+    VariablesResponse,
 };
 use debug_types::types::{
-    Capabilities, ChecksumAlgorithm, Scope, Source, StackFrame, Thread, Variable,
+    Breakpoint, Capabilities, ChecksumAlgorithm, Scope, Source, SourceBreakpoint, StackFrame,
+    Thread, Variable,
 };
 use debug_types::{MessageKind, ProtocolMessage};
 
 use clvmr::allocator::Allocator;
 
+use chialisp::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
+use chialisp::classic::clvm::sexp::sexp_as_bin;
+use chialisp::classic::clvm_tools::clvmc::compile_clvm_text;
+use chialisp::classic::clvm_tools::clvmc::CompileError;
 use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 
+use chialisp::compiler::cldb::hex_to_modern_sexp;
+use chialisp::compiler::cldb_hierarchy::{HierarchialRunner, HierarchialStepResult, RunPurpose};
 use chialisp::compiler::compiler::DefaultCompilerOpts;
-use chialisp::compiler::sexp::{decode_string, SExp};
+use chialisp::compiler::comptypes::{CompileErr, CompileForm, CompilerOpts, FrontendOutput};
+use chialisp::compiler::frontend::frontend;
+use chialisp::compiler::runtypes::RunFailure;
+use chialisp::compiler::sexp::{decode_string, parse_sexp, SExp};
 use chialisp::compiler::srcloc::Srcloc;
 
 use crate::dbg::compopts::DbgCompilerOpts;
-use crate::dbg::obj::{ObjLaunchArgs, RunningDebugger, TargetDepth};
-use crate::dbg::source::{parse_srcloc, StoredScope};
 use crate::dbg::types::MessageHandler;
+#[cfg(test)]
+use crate::interfaces::EPrintWriter;
 use crate::interfaces::{IFileReader, ILogWriter};
-use crate::lsp::types::ConfigJson;
+use crate::lsp::types::{ConfigJson, DocPosition, DocRange};
 
 // Lifecycle:
 // (a (code... ) (c arg ...))
@@ -37,6 +52,8 @@ use crate::lsp::types::ConfigJson;
 // (code ...)
 // We enter (code ...) proper via the OpResult of (a ... args) and can fish the
 // arguments.  After that, we're running the subfunction.
+
+const LARGE_COLUMN: u32 = 100000;
 
 /// Things which are in the launch request in practice but are not part of the
 /// documented minimal interface to this data.  Since these fields are ad-hoc
@@ -49,8 +66,6 @@ pub struct ExtraLaunchData {
     args: Option<Vec<String>>,
     #[serde(rename = "program")]
     program: Option<String>,
-    #[serde(rename = "symbols")]
-    symbols: Option<String>,
 }
 
 /// Used to make some aspects of deserializing easier via serde_json easier.
@@ -61,9 +76,436 @@ pub struct RequestContainer<T> {
     arguments: T,
 }
 
-pub struct LaunchArgs<'a> {
-    proto_msg: &'a ProtocolMessage,
-    obj_launch_args: ObjLaunchArgs<'a>,
+/// When stepping in or out, set a depth to stop at if reached before a breakpoint.
+#[derive(Clone, Debug)]
+pub enum TargetDepth {
+    /// Step out to this depth.
+    LessThan(usize),
+    /// Stop when the depth is the same as the current depth.
+    LessOrEqual(usize),
+}
+
+/// A structure containing what we know about the code as we passed the entry into
+/// this scope.  Since CLVM doesn't model the stack in the same way as a
+/// traditional vm, we synthesize a stack as we go.  cldh_hierarchy will tell us
+/// that the shape of the stack changed, and we'll push and pop frames as needed
+/// to match.  This contains our understanding of the state of execution when
+/// each frame was pushed.
+#[derive(Clone, Debug)]
+pub struct StoredScope {
+    scope_id: u32,
+
+    name: String,
+    named_args: HashMap<String, Rc<SExp>>,
+
+    rundata: Option<BTreeMap<String, String>>,
+
+    source: Srcloc,
+}
+
+#[derive(Clone, Debug)]
+struct RecognizedBreakpoint {
+    // hash: String, // Future: break by hash (clippy)
+    spec: Breakpoint,
+}
+
+/// This is a running debugger.  It's treated as an object with mutability via
+/// its step and set_breakpoints methods.  It is the primary object that implements
+/// tracking the debug state using the transitions emitted by the HierarchialRunner
+/// it holds.
+///
+/// It is created by the launch() method of Debugger.
+pub struct RunningDebugger {
+    pub initialized: InitializeRequestArguments,
+    pub launch_info: LaunchRequestArguments,
+    target_depth: Option<TargetDepth>,
+    stopped_reason: Option<StoppedReason>,
+
+    source_file: String,
+    compiled: Option<FrontendOutput>,
+
+    running: bool,
+    run: HierarchialRunner,
+    symbols: Rc<HashMap<String, String>>,
+    output_stack: Vec<StoredScope>,
+    result: Option<String>,
+
+    breakpoints: HashMap<String, HashMap<String, RecognizedBreakpoint>>,
+    next_bp_id: usize,
+    pub at_breakpoint: Option<Breakpoint>,
+
+    pub opts: Rc<dyn CompilerOpts>,
+}
+
+fn fuzzy_file_match(location_filename: &str, want_filename: &str) -> bool {
+    if let (Some(location_fn), Some(want_fn)) = (
+        PathBuf::from(location_filename).file_name(),
+        PathBuf::from(want_filename).file_name(),
+    ) {
+        location_fn == want_fn
+    } else {
+        false
+    }
+}
+
+#[test]
+fn test_fuzzy_file_match_1() {
+    assert!(fuzzy_file_match("test/foo/bar.clsp", "bar/baz/bar.clsp"));
+}
+
+fn resolve_function(symbols: Rc<HashMap<String, String>>, name: &str) -> Option<String> {
+    for (k, v) in symbols.iter() {
+        if v == name {
+            return Some(k.clone());
+        }
+    }
+
+    None
+}
+
+#[test]
+fn test_resolve_function_1() {
+    let symbols_map = HashMap::from([(
+        "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de".to_string(),
+        "fact".to_string(),
+    )]);
+    let symbols = Rc::new(symbols_map);
+    assert_eq!(
+        resolve_function(symbols, "fact"),
+        Some("de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de".to_string())
+    );
+}
+
+/// Given symbols, possibly a CompileForm and a SourceBreakpoint, try a few tricks
+/// to figure out where we should stop in the source when a breakpoint is set.
+///
+/// This can certainly be improved.
+fn find_location(
+    symbols: Rc<HashMap<String, String>>,
+    compiled: &Option<FrontendOutput>,
+    log: Rc<dyn ILogWriter>,
+    file: &str,
+    b: &SourceBreakpoint,
+) -> Option<(String, Srcloc)> {
+    let whole_line = DocRange {
+        start: DocPosition {
+            line: b.line - 1,
+            character: 0,
+        },
+        end: DocPosition {
+            line: b.line - 1,
+            character: LARGE_COLUMN,
+        },
+    };
+    let breakpoint_range = b
+        .column
+        .map(|_col| DocRange {
+            start: DocPosition {
+                line: b.line - 1,
+                character: 0,
+            },
+            end: DocPosition {
+                line: b.line - 1,
+                character: LARGE_COLUMN,
+            },
+        })
+        .unwrap_or_else(|| whole_line.clone());
+
+    let breakpoint_loc = breakpoint_range.to_srcloc(file);
+    for (k, v) in symbols.iter() {
+        if let Some(parsed_srcloc) = parse_srcloc(v) {
+            let borrowed_filename: &String = parsed_srcloc.file.borrow();
+            if !fuzzy_file_match(file, borrowed_filename) {
+                continue;
+            }
+            let normalized_loc = Srcloc::new(
+                breakpoint_loc.file.clone(),
+                parsed_srcloc.line,
+                parsed_srcloc.col,
+            );
+            if normalized_loc.overlap(&breakpoint_loc) {
+                return Some((k.clone(), parsed_srcloc.clone()));
+            }
+        }
+    }
+
+    let whole_line_loc = whole_line.to_srcloc(file);
+    compiled.as_ref().and_then(|c| {
+        for h in c.compileform().helpers.iter() {
+            let original_loc = h.loc();
+            let original_loc_file: &String = original_loc.file.borrow();
+            if !fuzzy_file_match(original_loc_file, file) {
+                continue;
+            }
+            let normalized_loc = Srcloc::new(
+                whole_line_loc.file.clone(),
+                original_loc.line,
+                original_loc.col,
+            );
+            log.log(&format!("{normalized_loc} vs target loc {whole_line_loc}"));
+            if whole_line_loc.overlap(&normalized_loc) {
+                log.log(&format!("found function {}", decode_string(h.name())));
+                return resolve_function(symbols, &decode_string(h.name()))
+                    .map(|funhash| (funhash, original_loc));
+            }
+        }
+
+        None
+    })
+}
+
+#[test]
+fn test_simple_find_location_classic_symbols_1() {
+    let log = Rc::new(EPrintWriter::new());
+    let symbols_map = HashMap::from([(
+        "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de".to_string(),
+        "fact".to_string(),
+    )]);
+    let symbols = Rc::new(symbols_map);
+    let program =
+        "(mod (X)\n  (defun fact (X) (if (= X 1) 1 (* X (fact (- X 1)))))\n  (fact 5)\n  )";
+    let parsed = parse_sexp(Srcloc::start("fact.clsp"), program.bytes()).expect("should parse");
+    let opts = Rc::new(DefaultCompilerOpts::new("fact.clsp"));
+    let compiled = frontend(opts, &parsed).expect("should compile");
+    let breakpoint_spec = SourceBreakpoint {
+        column: Some(0),
+        condition: None,
+        hit_condition: None,
+        line: 2,
+        log_message: None,
+    };
+    let (hash, _) = find_location(symbols, &Some(compiled), log, "fact.clsp", &breakpoint_spec)
+        .expect("should be found");
+    assert_eq!(
+        hash,
+        "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de"
+    );
+}
+
+impl RunningDebugger {
+    /// Given a request from the consumer, try to find and vend the requested
+    /// source file.  This can become a lot more sophisticated.  We might consider
+    /// storing the actual input files and other stuff in the symbols.
+    ///
+    /// In its current incarnation, this tries the CompilerOpts in RunningDebugger
+    /// to access the filesystem via the abstraction it carries.
+    fn get_source_file(
+        &self,
+        log: Rc<dyn ILogWriter>,
+        sfargs: &SourceArguments,
+    ) -> Option<ResponseBody> {
+        log.log(&format!("get_source_file {sfargs:?}"));
+        sfargs
+            .source
+            .as_ref()
+            .and_then(|s| s.name.as_ref())
+            .and_then(|n| {
+                self.opts
+                    .read_new_file(self.source_file.to_string(), n.to_string())
+                    .ok()
+            })
+            .map(|content| {
+                ResponseBody::Source(SourceResponse {
+                    content: String::from_utf8(content.1.clone()).unwrap(),
+                    mime_type: Some("text/plain".to_owned()),
+                })
+            })
+    }
+
+    /// Set these breakpoints in the source file they're indicated for.
+    fn set_breakpoints(
+        &mut self,
+        log: Rc<dyn ILogWriter>,
+        s: &Source,
+        breakpoints: Vec<SourceBreakpoint>,
+    ) -> Vec<Breakpoint> {
+        let use_path = s
+            .path
+            .as_ref()
+            .cloned()
+            .map(Some)
+            .unwrap_or_else(|| s.name.clone());
+        log.log(&format!("s.path {:?} s.name {:?}", s.path, s.name));
+        let bp_id_start = self.next_bp_id;
+        self.next_bp_id += breakpoints.len();
+
+        let empty_breakpoint = |(i, b): (usize, &SourceBreakpoint)| Breakpoint {
+            id: Some(i + bp_id_start),
+            column: b.column,
+            end_column: b.column,
+            line: Some(b.line),
+            end_line: Some(b.line),
+            instruction_reference: None,
+            message: Some("No source file to break in".to_string()),
+            offset: None,
+            source: None,
+            verified: false,
+        };
+
+        if let Some(p) = use_path {
+            log.log(&format!("path {p}"));
+
+            // Clear previous breakpoints for the translation unit.
+            self.breakpoints.remove(&p);
+
+            let mut inserted_breakpoints = HashMap::new();
+            let mut reported_breakpoints = Vec::new();
+
+            for (i, b) in breakpoints.iter().enumerate() {
+                // Verfified if we overlap at least one location in the symbols
+                // We.ll be simple and set it to the first matching point following
+                // the given location.
+                if let Some((hash, found)) =
+                    find_location(self.symbols.clone(), &self.compiled, log.clone(), &p, b)
+                {
+                    let end_col = found.until.clone().map(|e| e.col as u32);
+                    let end_line = found.until.map(|e| e.line as u32);
+                    let bp = Breakpoint {
+                        id: Some(i + bp_id_start),
+                        line: Some(found.line as u32),
+                        column: Some(found.col as u32),
+                        end_line,
+                        end_column: end_col,
+                        message: None,
+                        offset: None,
+                        instruction_reference: None,
+                        source: Some(s.clone()),
+                        verified: true,
+                    };
+                    reported_breakpoints.push(bp.clone());
+                    inserted_breakpoints.insert(
+                        hash.clone(),
+                        RecognizedBreakpoint {
+                            // hash,
+                            spec: bp,
+                        },
+                    );
+                } else {
+                    reported_breakpoints.push(empty_breakpoint((i, b)));
+                }
+            }
+
+            self.breakpoints.insert(p, inserted_breakpoints.clone());
+
+            reported_breakpoints
+        } else {
+            breakpoints
+                .iter()
+                .enumerate()
+                .map(empty_breakpoint)
+                .collect()
+        }
+    }
+
+    fn get_stack_depth(&self) -> usize {
+        self.output_stack.len()
+    }
+
+    fn real_step(
+        &mut self,
+        frame: StoredScope,
+        info: BTreeMap<String, String>,
+    ) -> Option<BTreeMap<String, String>> {
+        let running_frames = self
+            .run
+            .running
+            .iter()
+            .map(|f| f.purpose.clone())
+            .filter(|p| matches!(p, RunPurpose::Main))
+            .count();
+
+        // Ensure we're showing enough frames.
+        if running_frames >= self.output_stack.len() {
+            self.output_stack.push(frame.clone());
+        }
+
+        if running_frames < self.output_stack.len() {
+            if let Some(popped) = self.output_stack.pop() {
+                if !self.output_stack.is_empty() {
+                    let last_idx = self.output_stack.len() - 1;
+                    self.output_stack[last_idx].rundata = popped.rundata;
+                }
+            }
+        }
+
+        if !self.output_stack.is_empty() {
+            let last_idx = self.output_stack.len() - 1;
+            self.output_stack[last_idx] = frame;
+        }
+
+        Some(info)
+    }
+
+    /// Step the clvm by one tick, resulting in possibly new information and
+    /// possibly a stack change.
+    fn step(&mut self, log: Rc<dyn ILogWriter>) -> Option<BTreeMap<String, String>> {
+        // Clear breakpoint.
+        self.at_breakpoint = None;
+
+        loop {
+            if self.run.is_ended() {
+                return None;
+            }
+
+            match self.run.step() {
+                Ok(HierarchialStepResult::ShapeChange) => {
+                    // Nothing.
+                }
+                Ok(HierarchialStepResult::Info(Some(info))) => {
+                    if self.run.running.is_empty() {
+                        return None;
+                    }
+
+                    let frame_idx = self.run.running.len() - 1;
+                    let frame = &self.run.running[frame_idx];
+                    let step = frame.run.current_step();
+                    let frame_hex_string =
+                        Bytes::new(Some(BytesFromType::Raw(frame.function_hash.clone()))).hex();
+
+                    for (_translation_unit, breakpoints) in self.breakpoints.iter() {
+                        if let Some(bp) = breakpoints.get(&frame_hex_string) {
+                            // Break here.
+                            log.log(&format!("reached breakpoint {:?}", bp.spec));
+                            self.at_breakpoint = Some(bp.spec.clone());
+                        }
+                    }
+
+                    if let Some(result) = info.get("Value") {
+                        self.result = Some(result.clone());
+                    }
+
+                    return self.real_step(
+                        StoredScope {
+                            scope_id: (frame_idx + 1) as u32,
+                            name: frame.function_name.clone(),
+
+                            source: step.loc(),
+                            named_args: frame.named_args.clone(),
+                            rundata: Some(info.clone()),
+                        },
+                        info,
+                    );
+                }
+                Ok(HierarchialStepResult::Info(None)) => {
+                    // Nothing
+                }
+                Ok(HierarchialStepResult::Done(Some(_))) => {
+                    // I don't think anything is needed.
+                }
+                Ok(HierarchialStepResult::Done(None)) => {
+                    // Nothing
+                }
+                Err(RunFailure::RunErr(l, e)) => {
+                    println!("Runtime Error: {l}: {e}");
+                    // Nothing
+                }
+                Err(RunFailure::RunExn(l, e)) => {
+                    println!("Raised exception: {l}: {e}");
+                    // Nothing
+                }
+            }
+        }
+    }
 }
 
 /// State diagram for the debugger.
@@ -187,11 +629,197 @@ fn get_initialize_response() -> InitializeResponse {
     }
 }
 
+fn is_mod(sexp: Rc<SExp>) -> bool {
+    if let SExp::Cons(_, a, _) = sexp.borrow() {
+        if let SExp::Atom(_, n) = a.borrow() {
+            n == b"mod"
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+fn is_hex_file(filedata: &[u8]) -> bool {
+    filedata.iter().all(|b| {
+        b.is_ascii_whitespace()
+            || (*b >= b'0' && *b <= b'9')
+            || (*b >= b'a' && *b <= b'f')
+            || (*b >= b'A' && *b <= b'F')
+    })
+}
+
+// Try to cut the filename up at dots and find a matching .sym file to some
+// prefix of the components.
+// fact.clvm.hex -> fact.clvm.hex.sym, fact.clvm.sym, fact.sym
+// Stop at the proper file name.
+// Return the name of the located file and the content.
+fn try_locate_related_file(
+    fs: Rc<dyn IFileReader>,
+    fname: &str,
+    new_ext: &str,
+) -> Option<(String, Vec<u8>)> {
+    let path_components = PathBuf::from(fname);
+    if let (Some(directory), Some(only_filename)) =
+        (path_components.parent(), path_components.file_name())
+    {
+        if let Some(rust_str_filename) = only_filename.to_str() {
+            let filename_bytes = rust_str_filename.as_bytes().to_vec();
+            let mut dots: Vec<usize> = filename_bytes
+                .iter()
+                .copied()
+                .enumerate()
+                .filter(|(_, ch)| *ch == b'.')
+                .map(|(i, _)| i)
+                .collect();
+            dots.push(only_filename.len());
+            for d in dots.iter() {
+                let mut synthesized_filename: Vec<u8> =
+                    filename_bytes.iter().copied().take(*d).collect();
+                synthesized_filename.append(&mut new_ext.as_bytes().to_vec());
+                let synth_fname = PathBuf::from(&decode_string(&synthesized_filename));
+
+                if let Some(total_filename) = directory.join(synth_fname).to_str() {
+                    if let Ok(content) = fs.read_content(total_filename) {
+                        return Some((total_filename.to_owned(), content.as_bytes().to_vec()));
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn try_locate_symbols(fs: Rc<dyn IFileReader>, fname: &str) -> Option<(String, Vec<u8>)> {
+    try_locate_related_file(fs, fname, ".sym")
+}
+
+fn try_locate_source_file(fs: Rc<dyn IFileReader>, fname: &str) -> Option<(String, Vec<u8>)> {
+    for ext in vec![".clsp", ".clvm"].iter() {
+        if let Some(res) = try_locate_related_file(fs.clone(), fname, ext) {
+            return Some(res);
+        }
+    }
+
+    None
+}
+
+struct RunStartData {
+    source_file: String,
+    program: Rc<SExp>,
+    program_lines: Vec<String>,
+    arguments: Rc<SExp>,
+    symbols: HashMap<String, String>,
+    // is_hex: bool, // Future: if tools need to know this. (clippy)
+    compiled: Option<FrontendOutput>,
+}
+
+#[derive(Clone, Debug)]
+enum SrclocParseAction {
+    ReadingFileName,
+    ReadingLineNumber(usize, usize),
+    AfterLineNumber(usize, usize),
+    ReadingColumn(usize, usize, usize, Option<usize>),
+}
+
+struct ParsedSrclocPart {
+    file: Vec<u8>,
+    line: usize,
+    col: usize,
+    ext: Option<usize>,
+}
+
+struct LaunchArgs<'a> {
+    proto_msg: &'a ProtocolMessage,
+    name: &'a str,
+    init_args: &'a InitializeRequestArguments,
+    launch_request: &'a LaunchRequestArguments,
+    program: &'a str,
+    args_for_program: &'a [String],
+    stop_on_entry: bool,
+}
+
+/// A simple parser for srcloc for recovering them from messages and symbols.
+pub fn parse_srcloc(s: &str) -> Option<Srcloc> {
+    let parse_one_loc = |skip| {
+        let mut parse_state = SrclocParseAction::ReadingFileName;
+        for (i, ch) in s.as_bytes().iter().skip(skip).copied().enumerate() {
+            match (&parse_state, ch) {
+                (SrclocParseAction::ReadingFileName, b'(') => {
+                    parse_state = SrclocParseAction::ReadingLineNumber(i, 0);
+                }
+                (SrclocParseAction::ReadingFileName, _) => {}
+                (SrclocParseAction::ReadingLineNumber(eof, l), b')') => {
+                    parse_state = SrclocParseAction::AfterLineNumber(*eof, *l);
+                }
+                (SrclocParseAction::ReadingLineNumber(eof, l), ch) => {
+                    if !ch.is_ascii_digit() {
+                        return None;
+                    }
+                    parse_state = SrclocParseAction::ReadingLineNumber(
+                        *eof,
+                        10 * *l + ((ch - b'0') as usize),
+                    );
+                }
+                (SrclocParseAction::AfterLineNumber(eof, l), b':') => {
+                    parse_state = SrclocParseAction::ReadingColumn(*eof, *l, 0, None);
+                }
+                (SrclocParseAction::AfterLineNumber(_, _), _) => {
+                    return None;
+                }
+                (SrclocParseAction::ReadingColumn(eof, l, c, _), b'-') => {
+                    parse_state = SrclocParseAction::ReadingColumn(*eof, *l, *c, Some(i + 1));
+                }
+                (SrclocParseAction::ReadingColumn(eof, l, c, e), ch) => {
+                    if !ch.is_ascii_digit() {
+                        return None;
+                    }
+                    parse_state = SrclocParseAction::ReadingColumn(
+                        *eof,
+                        *l,
+                        10 * *c + ((ch - b'0') as usize),
+                        *e,
+                    );
+                }
+            }
+        }
+
+        if let SrclocParseAction::ReadingColumn(f, line, col, ext) = parse_state {
+            Some(ParsedSrclocPart {
+                file: s.as_bytes().iter().copied().take(f).collect(),
+                line,
+                col,
+                ext,
+            })
+        } else {
+            None
+        }
+    };
+
+    parse_one_loc(0).and_then(|parsed| {
+        let filename_rc = Rc::new(decode_string(&parsed.file));
+        let loc = Srcloc::new(filename_rc.clone(), parsed.line, parsed.col);
+        if let Some(ext) = parsed.ext {
+            parse_one_loc(ext).map(|second| {
+                if second.file != parsed.file {
+                    // Incomplete range, treat the head as a marker.
+                    return loc;
+                }
+                loc.ext(&Srcloc::new(filename_rc, second.line, second.col))
+            })
+        } else {
+            Some(loc)
+        }
+    })
+}
+
 impl Debugger {
     fn get_source_loc(&self, running: &RunningDebugger, name: &str) -> Option<Srcloc> {
         let get_helper_loc = |name: &str| {
             if let Some(compiled) = running.compiled.as_ref() {
-                for h in compiled.helpers.iter() {
+                for h in compiled.compileform().helpers.iter() {
                     if decode_string(h.name()) == name {
                         return Some(h.loc());
                     }
@@ -232,6 +860,111 @@ impl Debugger {
         Ok(decoded_chialisp_json)
     }
 
+    /// Try to obtain anything we're able to locate related to the chialisp program
+    /// or clvm hex that was launched.
+    fn read_program_data(
+        &self,
+        allocator: &mut Allocator,
+        opts: Rc<dyn CompilerOpts>,
+        _i: &InitializeRequestArguments,
+        _l: &LaunchRequestArguments,
+        name: &str,
+        read_in_file: &[u8],
+    ) -> Result<RunStartData, String> {
+        let program_lines: Vec<String> = read_in_file.lines().map(|x| x.unwrap()).collect();
+        let parse_err_map = |e: (Srcloc, String)| format!("{}: {}", e.0, e.1);
+        let compile_err_map = |e: CompileErr| format!("{}: {}", e.0, e.1);
+        let run_err_map = |e: RunFailure| {
+            let res = match e {
+                RunFailure::RunErr(l, e) => format!("{l}: {e}"),
+                RunFailure::RunExn(l, v) => format!("{l}: exception {v}"),
+            };
+            self.log.log(&format!("runfailure {res}"));
+            res
+        };
+
+        let mut use_symbol_table = HashMap::new();
+        let is_hex = is_hex_file(read_in_file);
+
+        let mut compiled = None;
+        if let Some((source_file, source_content)) = try_locate_source_file(self.fs.clone(), name) {
+            let source_parsed =
+                parse_sexp(Srcloc::start(&source_file), source_content.iter().copied())
+                    .map_err(parse_err_map)?;
+
+            let frontend_compiled =
+                frontend(opts.clone(), &source_parsed).map_err(compile_err_map)?;
+
+            compiled = Some(frontend_compiled);
+        }
+
+        let mut parsed_program = if is_hex {
+            let prog_srcloc = Srcloc::start(name);
+
+            // Synthesize content by disassembling the file.
+            use_symbol_table =
+                if let Some((symfile, symdata)) = try_locate_symbols(self.fs.clone(), name) {
+                    serde_json::from_str(&decode_string(&symdata))
+                        .map_err(|_| format!("Failure decoding symbols from {symfile}"))?
+                } else {
+                    HashMap::new()
+                };
+
+            hex_to_modern_sexp(
+                allocator,
+                &use_symbol_table,
+                prog_srcloc,
+                &decode_string(read_in_file),
+            )
+            .map_err(run_err_map)?
+        } else {
+            let parsed = parse_sexp(Srcloc::start(name), read_in_file.iter().copied())
+                .map_err(parse_err_map)?;
+
+            if parsed.is_empty() {
+                return Err(format!("Empty program file {name}"));
+            }
+
+            parsed[0].clone()
+        };
+
+        if is_mod(parsed_program.clone()) {
+            // Compile program.
+            let clvm_res = compile_clvm_text(
+                allocator,
+                opts.clone(),
+                &mut use_symbol_table,
+                &decode_string(read_in_file),
+                name,
+                true,
+            )
+            .map_err(|e| {
+                let formatted = match e {
+                    CompileError::Classic(_x, y) => y,
+                    CompileError::Modern(l, v) => format!("{l}: {v}"),
+                };
+                self.log.log(&format!("error compiling: {formatted}"));
+                formatted
+            })?;
+            let bin = sexp_as_bin(allocator, clvm_res).hex();
+            parsed_program =
+                hex_to_modern_sexp(allocator, &use_symbol_table, Srcloc::start(name), &bin)
+                    .map_err(run_err_map)?;
+        };
+
+        let arguments = Rc::new(SExp::Nil(parsed_program.loc()));
+
+        Ok(RunStartData {
+            source_file: name.to_owned(),
+            program: parsed_program,
+            program_lines,
+            arguments,
+            symbols: use_symbol_table,
+            // is_hex,
+            compiled,
+        })
+    }
+
     /// Given a launch command and the extra data it receives from launch.json,
     /// try to locate enough pieces to run a debug session.
     ///
@@ -246,22 +979,62 @@ impl Debugger {
         let mut allocator = Allocator::new();
         let mut seq_nr = self.msg_seq;
         let config = self.read_chialisp_json()?;
-        let def_opts = Rc::new(DefaultCompilerOpts::new(&launch_args.obj_launch_args.name));
+        let read_in_file = self.fs.read_content(launch_args.program)?;
+        let def_opts = Rc::new(DefaultCompilerOpts::new(&launch_args.name));
         let opts = Rc::new(DbgCompilerOpts::new(
             def_opts,
             self.log.clone(),
             self.fs.clone(),
             &config.include_paths,
         ));
-        let debugger = RunningDebugger::create(
+        let mut launch_data = self.read_program_data(
             &mut allocator,
-            self.fs.clone(),
-            self.log.clone(),
-            self.runner.clone(),
             opts.clone(),
-            &launch_args.obj_launch_args,
+            launch_args.init_args,
+            launch_args.launch_request,
+            launch_args.program,
+            read_in_file.as_bytes(),
         )?;
-        let state = State::Launched(debugger);
+
+        if !launch_args.args_for_program.is_empty() {
+            let parsed_argv0 = parse_sexp(
+                Srcloc::start("*args*"),
+                launch_args.args_for_program[0].bytes(),
+            )
+            .map_err(|(l, e)| format!("{l}: {e}"))?;
+            if !parsed_argv0.is_empty() {
+                launch_data.arguments = parsed_argv0[0].clone();
+            }
+        }
+
+        let symbol_rc = Rc::new(launch_data.symbols);
+
+        let run = HierarchialRunner::new(
+            self.runner.clone(),
+            self.prim_map.clone(),
+            Some(launch_args.name.to_string()),
+            Rc::new(launch_data.program_lines),
+            symbol_rc.clone(),
+            launch_data.program,
+            launch_data.arguments,
+        );
+        let state = State::Launched(RunningDebugger {
+            initialized: launch_args.init_args.clone(),
+            launch_info: launch_args.launch_request.clone(),
+            running: !launch_args.stop_on_entry,
+            run,
+            opts,
+            output_stack: Vec::new(),
+            stopped_reason: None,
+            target_depth: None,
+            result: None,
+            source_file: launch_data.source_file,
+            compiled: launch_data.compiled,
+            breakpoints: HashMap::new(),
+            next_bp_id: 1,
+            at_breakpoint: None,
+            symbols: symbol_rc,
+        });
 
         seq_nr += 1;
         let mut out_messages = vec![ProtocolMessage {
@@ -275,7 +1048,7 @@ impl Debugger {
         }];
 
         // Signal that we're paused if stop on entry.
-        if launch_args.obj_launch_args.stop_on_entry {
+        if launch_args.stop_on_entry {
             seq_nr += 1;
             out_messages.push(ProtocolMessage {
                 seq: self.msg_seq,
@@ -357,10 +1130,6 @@ impl MessageHandler<ProtocolMessage> for Debugger {
                         .as_ref()
                         .and_then(|l| l.arguments.args.clone())
                         .unwrap_or(vec![]);
-                    let symbols = launch_extra
-                        .as_ref()
-                        .and_then(|l| l.arguments.symbols.clone())
-                        .unwrap_or("".to_string());
                     if let Some(name) = &l.name {
                         let program = launch_extra
                             .and_then(|l| l.arguments.program)
@@ -368,14 +1137,12 @@ impl MessageHandler<ProtocolMessage> for Debugger {
 
                         let (new_seq, new_state, out_msgs) = self.launch(LaunchArgs {
                             proto_msg: pm,
-                            obj_launch_args: ObjLaunchArgs {
-                                init_args: &i,
-                                name,
-                                program: &program,
-                                args_for_program: &args,
-                                symbols: &symbols,
-                                stop_on_entry,
-                            },
+                            name,
+                            init_args: &i,
+                            launch_request: l,
+                            program: &program,
+                            args_for_program: &args,
+                            stop_on_entry,
                         })?;
                         self.msg_seq = new_seq;
                         self.state = new_state;

--- a/wasm/src/dbg/mod.rs
+++ b/wasm/src/dbg/mod.rs
@@ -2,4 +2,5 @@ pub mod compopts;
 pub mod handler;
 pub mod obj;
 pub mod server;
+pub mod source;
 pub mod types;

--- a/wasm/src/dbg/mod.rs
+++ b/wasm/src/dbg/mod.rs
@@ -2,5 +2,4 @@ pub mod compopts;
 pub mod handler;
 pub mod obj;
 pub mod server;
-pub mod source;
 pub mod types;

--- a/wasm/src/dbg/obj.rs
+++ b/wasm/src/dbg/obj.rs
@@ -406,7 +406,7 @@ fn test_simple_find_location_classic_symbols_1() {
         line: 2,
         log_message: None,
     };
-    let (hash, _) = find_location(symbols, &Some(compiled), log, "fact.clsp", &breakpoint_spec)
+    let (hash, _) = find_location(symbols, &Some(compiled.compileform().clone()), log, "fact.clsp", &breakpoint_spec)
         .expect("should be found");
     assert_eq!(
         hash,
@@ -500,7 +500,7 @@ fn translate_argument_names(lines: &[Rc<Vec<u8>>], sexp: Rc<SExp>) -> Rc<SExp> {
         )),
         SExp::Atom(l, _) => {
             let vrange = DocRange::from_srcloc(l.clone()).to_range();
-            if let Some(replacement) = get_positional_text(lines, &vrange.start) {
+            if let Some(replacement) = get_positional_text(&lines, &vrange.start) {
                 Rc::new(SExp::Atom(l.clone(), replacement.to_vec()))
             } else {
                 sexp.clone()
@@ -632,7 +632,7 @@ fn read_program_data(
             frontend(opts.clone(), &source_and_content.source_parsed).map_err(compile_err_map)?;
 
         inputs.source = Some(source_and_content);
-        inputs.compiled = Ok(Some(frontend_compiled));
+        inputs.compiled = Ok(Some(frontend_compiled.compileform().clone()));
     }
 
     let mut parsed_program = if inputs.is_hex {

--- a/wasm/src/dbg/obj.rs
+++ b/wasm/src/dbg/obj.rs
@@ -18,9 +18,7 @@ use chialisp::classic::clvm_tools::comp_input::RunAndCompileInputData;
 use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 use chialisp::classic::platform::argparse::ArgumentValue;
 use chialisp::compiler::cldb::hex_to_modern_sexp;
-use chialisp::compiler::cldb_hierarchy::{
-    HierarchialRunner, HierarchialStepResult, RunPurpose,
-};
+use chialisp::compiler::cldb_hierarchy::{HierarchialRunner, HierarchialStepResult, RunPurpose};
 #[cfg(test)]
 use chialisp::compiler::compiler::DefaultCompilerOpts;
 use chialisp::compiler::comptypes::{CompileErr, CompileForm, CompilerOpts, HelperForm};
@@ -406,8 +404,14 @@ fn test_simple_find_location_classic_symbols_1() {
         line: 2,
         log_message: None,
     };
-    let (hash, _) = find_location(symbols, &Some(compiled.compileform().clone()), log, "fact.clsp", &breakpoint_spec)
-        .expect("should be found");
+    let (hash, _) = find_location(
+        symbols,
+        &Some(compiled.compileform().clone()),
+        log,
+        "fact.clsp",
+        &breakpoint_spec,
+    )
+    .expect("should be found");
     assert_eq!(
         hash,
         "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de"

--- a/wasm/src/lsp/completion.rs
+++ b/wasm/src/lsp/completion.rs
@@ -52,7 +52,7 @@ fn complete_variable_name(
             .filter_map(|(l, n)| {
                 if l.line > 0 && l.col > 1 {
                     get_positional_text(
-                        &doc,
+                        &doc.text,
                         &Position {
                             line: (l.line - 1) as u32,
                             character: (l.col - 1) as u32,
@@ -183,7 +183,7 @@ impl LSPCompletionRequestHandler for LSPServiceProvider {
                 on_previous_character
             ));
 
-            if let Some(cpl) = get_positional_text(&doc, &on_previous_character) {
+            if let Some(cpl) = get_positional_text(&doc.text, &on_previous_character) {
                 let mut found_scopes = Vec::new();
                 let want_position = Srcloc::new(
                     Rc::new(uristring.clone()),

--- a/wasm/src/lsp/completion.rs
+++ b/wasm/src/lsp/completion.rs
@@ -52,7 +52,7 @@ fn complete_variable_name(
             .filter_map(|(l, n)| {
                 if l.line > 0 && l.col > 1 {
                     get_positional_text(
-                        &doc.text,
+                        &doc,
                         &Position {
                             line: (l.line - 1) as u32,
                             character: (l.col - 1) as u32,
@@ -183,7 +183,7 @@ impl LSPCompletionRequestHandler for LSPServiceProvider {
                 on_previous_character
             ));
 
-            if let Some(cpl) = get_positional_text(&doc.text, &on_previous_character) {
+            if let Some(cpl) = get_positional_text(&doc, &on_previous_character) {
                 let mut found_scopes = Vec::new();
                 let want_position = Srcloc::new(
                     Rc::new(uristring.clone()),

--- a/wasm/src/lsp/compopts.rs
+++ b/wasm/src/lsp/compopts.rs
@@ -11,11 +11,14 @@ use crate::lsp::patch::{compute_comment_lines, split_text};
 use crate::lsp::types::DocData;
 use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 use chialisp::compiler::compiler::{compile_pre_forms, STANDARD_MACROS};
-use chialisp::compiler::comptypes::{CompileErr, CompilerOpts, HasCompilerOptsDelegation};
+use chialisp::compiler::comptypes::{
+    CompileErr, CompilerOpts, CompilerOutput, HasCompilerOptsDelegation,
+};
 use chialisp::compiler::dialect::{DialectDescription, KNOWN_DIALECTS};
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
+use chialisp::compiler::BasicCompileContext;
 use chialisp::compiler::CompileContextWrapper;
 
 use super::patch::get_bytes;
@@ -77,19 +80,11 @@ impl HasCompilerOptsDelegation for LSPCompilerOpts {
 
     fn override_compile_program(
         &self,
-        allocator: &mut Allocator,
-        runner: Rc<dyn TRunProgram>,
+        context: &mut BasicCompileContext,
         sexp: Rc<SExp>,
-        symbol_table: &mut HashMap<String, String>,
-    ) -> Result<SExp, CompileErr> {
+    ) -> Result<CompilerOutput, CompileErr> {
         let me = Rc::new(self.clone());
-        let mut context_wrapper = CompileContextWrapper::new(
-            allocator,
-            runner,
-            symbol_table,
-            get_optimizer(&Srcloc::start(&self.filename()), me.clone())?,
-        );
-        compile_pre_forms(&mut context_wrapper.context, me, &[sexp])
+        compile_pre_forms(context, me, &[sexp])
     }
 }
 

--- a/wasm/src/lsp/handler.rs
+++ b/wasm/src/lsp/handler.rs
@@ -169,7 +169,9 @@ impl LSPServiceProvider {
                 }
                 IncludedFileSpec::Import(imp) => {
                     let mut found_include = false;
-                    let target_file = imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+                    let target_file = imp
+                        .longname
+                        .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
                     for path in self.config.include_paths.clone().iter() {
                         let target_name = Path::new(&path)
                             .join(&decode_string(&target_file))
@@ -238,7 +240,7 @@ impl LSPServiceProvider {
                                     arguments: Some(vec![serde_json::to_value(&decode_string(
                                         &inc.filename,
                                     ))
-                                                         .unwrap()]),
+                                    .unwrap()]),
                                 }),
                                 is_preferred: None,
                                 disabled: None,

--- a/wasm/src/lsp/handler.rs
+++ b/wasm/src/lsp/handler.rs
@@ -87,26 +87,41 @@ impl LSPServiceProvider {
 
     // Update include state
     fn update_include_state(&mut self, parsed_file: &str, file_name: &[u8], file_found: bool) {
+        let mut matching_include_hashes = Vec::new();
+        let mut matching_import = false;
+
         if let Some(found) = self.parsed_documents.get_mut(parsed_file) {
-            let mut found_hash = None;
             for (h, inc) in found.includes.iter() {
                 match inc {
                     IncludedFileSpec::Include(inc) => {
                         if inc.filename == file_name {
-                            found_hash = Some(h.clone());
-                            break;
+                            matching_include_hashes.push(h.clone());
                         }
                     }
                     IncludedFileSpec::Import(imp) => {
-                        // XXX determine whether there's anything we should be doing here.
+                        let import_file = imp
+                            .longname
+                            .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+                        if import_file == file_name {
+                            matching_import = true;
+                        }
                     }
                 }
             }
 
-            if let Some(h) = &found_hash {
+            for h in matching_include_hashes.iter() {
                 if let Some(IncludedFileSpec::Include(inc)) = found.includes.get_mut(h) {
                     inc.found = Some(file_found);
                 }
+            }
+        }
+
+        if matching_import {
+            let key = (parsed_file.to_owned(), file_name.to_vec());
+            if file_found {
+                self.missing_import_files.remove(&key);
+            } else {
+                self.missing_import_files.insert(key);
             }
         }
     }
@@ -125,9 +140,7 @@ impl LSPServiceProvider {
                         }
                     }
                     IncludedFileSpec::Import(imp) => {
-                        if self.get_doc(uristring).is_none() {
-                            to_resolve.push((uristring, IncludedFileSpec::Import(imp.clone())));
-                        }
+                        to_resolve.push((uristring, IncludedFileSpec::Import(imp.clone())));
                     }
                 }
             }
@@ -156,15 +169,14 @@ impl LSPServiceProvider {
                         if let Some(target) = target_name {
                             if self.fs.read_content(&target).is_ok() {
                                 found_include = true;
-                                self.update_include_state(parsed, &i.filename, true);
                                 break;
                             }
                         }
                     }
 
+                    self.update_include_state(parsed, &i.filename, found_include);
                     if !found_include {
                         ask_ui_for_resolution.push(IncludedFileSpec::Include(i.clone()));
-                        self.update_include_state(parsed, &i.filename, false);
                     }
                 }
                 IncludedFileSpec::Import(imp) => {
@@ -180,9 +192,17 @@ impl LSPServiceProvider {
                         if let Some(target) = target_name {
                             if self.fs.read_content(&target).is_ok() {
                                 found_include = true;
-                                self.update_include_state(parsed, &target_file, true);
+                                break;
                             }
                         }
+                    }
+
+                    self.update_include_state(parsed, &target_file, found_include);
+                    if self
+                        .missing_import_files
+                        .contains(&(parsed.to_string(), target_file.clone()))
+                    {
+                        ask_ui_for_resolution.push(IncludedFileSpec::Import(imp.clone()));
                     }
                 }
             }
@@ -376,6 +396,7 @@ impl LSPServiceMessageHandler for LSPServiceProvider {
                                     self.log.log("reconfigured");
                                     self.config = config;
                                     self.parsed_documents.clear();
+                                    self.missing_import_files.clear();
                                     self.goto_defs.clear();
                                 }
                             } else if self

--- a/wasm/src/lsp/handler.rs
+++ b/wasm/src/lsp/handler.rs
@@ -98,7 +98,7 @@ impl LSPServiceProvider {
                         }
                     }
                     IncludedFileSpec::Import(imp) => {
-                        todo!();
+                        // XXX determine whether there's anything we should be doing here.
                     }
                 }
             }
@@ -220,6 +220,32 @@ impl LSPServiceProvider {
     ) -> Result<Vec<Message>, String> {
         let uristring = params.text_document.uri.to_string();
         let mut result_messages = Vec::new();
+        let emit_quick_fix_action = |result_messages: &mut Vec<Message>, name_loc, filename: Vec<u8>| {
+            if DocRange::from_srcloc(name_loc).to_range() == params.range {
+                let code_action = vec![CodeActionOrCommand::CodeAction(CodeAction {
+                    title: "Locate include path".to_string(),
+                    kind: Some(CodeActionKind::QUICKFIX),
+                    diagnostics: None,
+                    edit: None,
+                    command: Some(Command {
+                        title: "Locate include path".to_string(),
+                        command: "chialisp.locateIncludePath".to_string(),
+                        arguments: Some(vec![serde_json::to_value(&decode_string(
+                            &filename,
+                        ))
+                                             .unwrap()]),
+                    }),
+                    is_preferred: None,
+                    disabled: None,
+                    data: None,
+                })];
+                result_messages.push(Message::Response(Response {
+                    id: id.clone(),
+                    result: Some(serde_json::to_value(code_action).unwrap()),
+                    error: None,
+                }));
+            }
+        };
 
         // Double check parsed state.
         self.ensure_parsed_document(&uristring);
@@ -228,33 +254,12 @@ impl LSPServiceProvider {
             for (_, inc) in doc.includes.iter() {
                 match inc {
                     IncludedFileSpec::Include(inc) => {
-                        if DocRange::from_srcloc(inc.name_loc.clone()).to_range() == params.range {
-                            let code_action = vec![CodeActionOrCommand::CodeAction(CodeAction {
-                                title: "Locate include path".to_string(),
-                                kind: Some(CodeActionKind::QUICKFIX),
-                                diagnostics: None,
-                                edit: None,
-                                command: Some(Command {
-                                    title: "Locate include path".to_string(),
-                                    command: "chialisp.locateIncludePath".to_string(),
-                                    arguments: Some(vec![serde_json::to_value(&decode_string(
-                                        &inc.filename,
-                                    ))
-                                    .unwrap()]),
-                                }),
-                                is_preferred: None,
-                                disabled: None,
-                                data: None,
-                            })];
-                            result_messages.push(Message::Response(Response {
-                                id: id.clone(),
-                                result: Some(serde_json::to_value(code_action).unwrap()),
-                                error: None,
-                            }));
-                        }
+                        emit_quick_fix_action(&mut result_messages, inc.name_loc.clone(), inc.filename.clone());
                     }
                     IncludedFileSpec::Import(imp) => {
-                        todo!();
+                        // XXX detect a clinc import vs a program import.
+                        let filename = imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+                        emit_quick_fix_action(&mut result_messages, imp.nl.clone(), filename);
                     }
                 }
             }

--- a/wasm/src/lsp/handler.rs
+++ b/wasm/src/lsp/handler.rs
@@ -13,11 +13,13 @@ use lsp_types::{
 use lsp_server::{ErrorCode, Message, RequestId, Response};
 
 use crate::lsp::completion::LSPCompletionRequestHandler;
+use crate::lsp::parse::IncludedFileSpec;
 use crate::lsp::patch::{compute_comment_lines, split_text, LSPServiceProviderApplyDocumentPatch};
 use crate::lsp::semtok::LSPSemtokRequestHandler;
 use crate::lsp::types::{
     cast, ConfigJson, DocData, DocRange, IncludeData, InitState, LSPServiceProvider,
 };
+use chialisp::compiler::comptypes::LongNameTranslation;
 use chialisp::compiler::sexp::decode_string;
 use chialisp::compiler::srcloc::Srcloc;
 
@@ -88,14 +90,21 @@ impl LSPServiceProvider {
         if let Some(found) = self.parsed_documents.get_mut(parsed_file) {
             let mut found_hash = None;
             for (h, inc) in found.includes.iter() {
-                if inc.filename == file_name {
-                    found_hash = Some(h.clone());
-                    break;
+                match inc {
+                    IncludedFileSpec::Include(inc) => {
+                        if inc.filename == file_name {
+                            found_hash = Some(h.clone());
+                            break;
+                        }
+                    }
+                    IncludedFileSpec::Import(imp) => {
+                        todo!();
+                    }
                 }
             }
 
             if let Some(h) = &found_hash {
-                if let Some(inc) = found.includes.get_mut(h) {
+                if let Some(IncludedFileSpec::Include(inc)) = found.includes.get_mut(h) {
                     inc.found = Some(file_found);
                 }
             }
@@ -103,14 +112,23 @@ impl LSPServiceProvider {
     }
 
     // Return the includes that couldn't be resolved.
-    pub fn check_for_missing_include_files(&mut self, uristring: &str) -> Vec<IncludeData> {
+    pub fn check_for_missing_include_files(&mut self, uristring: &str) -> Vec<IncludedFileSpec> {
         let mut to_resolve = Vec::new();
 
         // Find includes we need to resolve
         if let Some(doc) = self.parsed_documents.get(uristring) {
             for (_, i) in doc.includes.iter() {
-                if i.found != Some(true) {
-                    to_resolve.push((uristring, i.clone()));
+                match i {
+                    IncludedFileSpec::Include(i) => {
+                        if i.found != Some(true) {
+                            to_resolve.push((uristring, IncludedFileSpec::Include(i.clone())));
+                        }
+                    }
+                    IncludedFileSpec::Import(imp) => {
+                        if self.get_doc(uristring).is_none() {
+                            to_resolve.push((uristring, IncludedFileSpec::Import(imp.clone())));
+                        }
+                    }
                 }
             }
         }
@@ -118,33 +136,53 @@ impl LSPServiceProvider {
         // Errors is specifically the ones we tried to resolve and failed.
         let mut ask_ui_for_resolution = Vec::new();
 
-        let to_read_files: Vec<(String, IncludeData)> = to_resolve
+        let to_read_files: Vec<(String, IncludedFileSpec)> = to_resolve
             .iter()
             .map(|(parsed, i)| (parsed.to_string(), i.clone()))
             .collect();
         for (parsed, i) in to_read_files.iter() {
-            if i.filename.is_empty() || i.filename[0] == b'*' || i.found == Some(true) {
-                continue;
-            }
+            match i {
+                IncludedFileSpec::Include(i) => {
+                    if i.filename.is_empty() || i.filename[0] == b'*' || i.found == Some(true) {
+                        continue;
+                    }
 
-            let mut found_include = false;
-            for path in self.config.include_paths.iter() {
-                let target_name = Path::new(&path)
-                    .join(&decode_string(&i.filename))
-                    .to_str()
-                    .map(|o| o.to_owned());
-                if let Some(target) = target_name {
-                    if self.fs.read_content(&target).is_ok() {
-                        found_include = true;
-                        self.update_include_state(parsed, &i.filename, true);
-                        break;
+                    let mut found_include = false;
+                    for path in self.config.include_paths.iter() {
+                        let target_name = Path::new(&path)
+                            .join(&decode_string(&i.filename))
+                            .to_str()
+                            .map(|o| o.to_owned());
+                        if let Some(target) = target_name {
+                            if self.fs.read_content(&target).is_ok() {
+                                found_include = true;
+                                self.update_include_state(parsed, &i.filename, true);
+                                break;
+                            }
+                        }
+                    }
+
+                    if !found_include {
+                        ask_ui_for_resolution.push(IncludedFileSpec::Include(i.clone()));
+                        self.update_include_state(parsed, &i.filename, false);
                     }
                 }
-            }
-
-            if !found_include {
-                ask_ui_for_resolution.push(i.clone());
-                self.update_include_state(parsed, &i.filename, false);
+                IncludedFileSpec::Import(imp) => {
+                    let mut found_include = false;
+                    let target_file = imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+                    for path in self.config.include_paths.clone().iter() {
+                        let target_name = Path::new(&path)
+                            .join(&decode_string(&target_file))
+                            .to_str()
+                            .map(|o| o.to_owned());
+                        if let Some(target) = target_name {
+                            if self.fs.read_content(&target).is_ok() {
+                                found_include = true;
+                                self.update_include_state(parsed, &target_file, true);
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -186,29 +224,36 @@ impl LSPServiceProvider {
 
         if let Some(doc) = self.parsed_documents.get(&uristring) {
             for (_, inc) in doc.includes.iter() {
-                if DocRange::from_srcloc(inc.name_loc.clone()).to_range() == params.range {
-                    let code_action = vec![CodeActionOrCommand::CodeAction(CodeAction {
-                        title: "Locate include path".to_string(),
-                        kind: Some(CodeActionKind::QUICKFIX),
-                        diagnostics: None,
-                        edit: None,
-                        command: Some(Command {
-                            title: "Locate include path".to_string(),
-                            command: "chialisp.locateIncludePath".to_string(),
-                            arguments: Some(vec![serde_json::to_value(&decode_string(
-                                &inc.filename,
-                            ))
-                            .unwrap()]),
-                        }),
-                        is_preferred: None,
-                        disabled: None,
-                        data: None,
-                    })];
-                    result_messages.push(Message::Response(Response {
-                        id: id.clone(),
-                        result: Some(serde_json::to_value(code_action).unwrap()),
-                        error: None,
-                    }));
+                match inc {
+                    IncludedFileSpec::Include(inc) => {
+                        if DocRange::from_srcloc(inc.name_loc.clone()).to_range() == params.range {
+                            let code_action = vec![CodeActionOrCommand::CodeAction(CodeAction {
+                                title: "Locate include path".to_string(),
+                                kind: Some(CodeActionKind::QUICKFIX),
+                                diagnostics: None,
+                                edit: None,
+                                command: Some(Command {
+                                    title: "Locate include path".to_string(),
+                                    command: "chialisp.locateIncludePath".to_string(),
+                                    arguments: Some(vec![serde_json::to_value(&decode_string(
+                                        &inc.filename,
+                                    ))
+                                                         .unwrap()]),
+                                }),
+                                is_preferred: None,
+                                disabled: None,
+                                data: None,
+                            })];
+                            result_messages.push(Message::Response(Response {
+                                id: id.clone(),
+                                result: Some(serde_json::to_value(code_action).unwrap()),
+                                error: None,
+                            }));
+                        }
+                    }
+                    IncludedFileSpec::Import(imp) => {
+                        todo!();
+                    }
                 }
             }
         }

--- a/wasm/src/lsp/mod.rs
+++ b/wasm/src/lsp/mod.rs
@@ -4,6 +4,7 @@ pub mod handler;
 pub mod parse;
 pub mod patch;
 pub mod reparse;
+pub mod resolve;
 pub mod semtok;
 pub mod types;
 

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -7,7 +7,7 @@ use lsp_types::Position;
 #[cfg(test)]
 use chialisp::compiler::compiler::DefaultCompilerOpts;
 use chialisp::compiler::comptypes::{
-    Binding, BindingPattern, BodyForm, CompileErr, CompileForm, FrontendOutput, HelperForm,
+    Binding, BindingPattern, BodyForm, CompileErr, CompileForm, Export, FrontendOutput, HelperForm,
     LetData, LetFormKind,
 };
 #[cfg(test)]
@@ -33,6 +33,8 @@ pub struct ParsedDoc {
     // it.  CompileForm is the result of frontend and is used for analyzing
     // chialisp in many different tools deriving from chialisp.
     pub compiled: CompileForm,
+    // Exports if module style.
+    pub exports: Vec<Export>,
     // The scope stack for this file.
     pub scopes: ParseScope,
     // Helpers in ReparsedHelper form.  We pulled these indiviually by identifying
@@ -64,6 +66,7 @@ impl ParsedDoc {
                 helpers: Default::default(),
                 exp: Rc::new(BodyForm::Quoted(nil)),
             },
+            exports: Vec::default(),
             scopes: ParseScope {
                 region: startloc,
                 kind: ScopeKind::Module,
@@ -400,10 +403,10 @@ fn test_not_is_first_in_list_next_word() {
 }
 
 // Given a position, return the identifier at that position.  Relies on find_ident.
-pub fn get_positional_text(lines: &DocData, position: &Position) -> Option<Vec<u8>> {
+pub fn get_positional_text(lines: &[Rc<Vec<u8>>], position: &Position) -> Option<Vec<u8>> {
     let pl = position.line as usize;
-    if pl < lines.text.len() {
-        let line = lines.text[pl].clone();
+    if pl < lines.len() {
+        let line = lines[pl].clone();
         find_ident(line, position.character)
     } else {
         None
@@ -415,7 +418,7 @@ fn test_get_positional_text() {
     let simple_doc = make_simple_test_doc_data_from_lines("test.clsp", &["(", "  hi there", ")"]);
     assert_eq!(
         get_positional_text(
-            &simple_doc,
+            &simple_doc.text,
             &Position {
                 line: 1,
                 character: 3
@@ -674,7 +677,7 @@ fn make_scope_stack_simple() {
     for v in program_scope.containing[1].containing[0].variables.iter() {
         let vrange = DocRange::from_srcloc(v.loc()).to_range();
         assert_eq!(
-            get_positional_text(&doc, &vrange.start),
+            get_positional_text(&doc.text, &vrange.start),
             Some(b"C".to_vec())
         );
     }
@@ -861,10 +864,15 @@ fn test_make_arg_set() {
 // Source files in chialisp are for legacy reasons all expected to contain only
 // one toplevel element, so the areas of interest that may move or change are at
 // the second level.
+//
+// In module style, there is no outside container.  We should detect which the
+// source file is and act accordingly.
 pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> Vec<DocRange> {
-    let mut ranges = Vec::new();
+    let mut ranges_1 = Vec::new();
+    let mut ranges_0 = Vec::new();
     let mut in_comment = false;
-    let mut start = None;
+    let mut start_1 = None;
+    let mut start_0 = None;
     let mut level = 0;
     let mut line = 0;
     let mut character = 0;
@@ -879,8 +887,11 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> Vec<DocRange> {
             in_comment = false;
         } else if i == b'(' {
             if !in_comment {
-                if level == 1 && start.is_none() {
-                    start = Some(DocPosition { line, character });
+                if level == 1 && start_1.is_none() {
+                    start_1 = Some(DocPosition { line, character });
+                }
+                if level == 0 {
+                    start_0 = Some(DocPosition { line, character });
                 }
                 level += 1;
             }
@@ -892,15 +903,27 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> Vec<DocRange> {
                 level -= 1;
 
                 if level == 1 {
-                    if let Some(s) = start.clone() {
-                        ranges.push(DocRange {
+                    if let Some(s) = start_1.clone() {
+                        ranges_1.push(DocRange {
                             start: s,
                             end: DocPosition {
                                 line,
                                 character: character + 1,
                             },
                         });
-                        start = None;
+                        start_1 = None;
+                    }
+                }
+                if level == 0 {
+                    if let Some(s) = start_0.clone() {
+                        ranges_0.push(DocRange {
+                            start: s,
+                            end: DocPosition {
+                                line,
+                                character: character + 1,
+                            },
+                        });
+                        start_0 = None;
                     }
                 }
             }
@@ -910,7 +933,13 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> Vec<DocRange> {
         }
     }
 
-    ranges
+    eprintln!("ranges_0 {ranges_0:?}");
+    eprintln!("ranges_1 {ranges_1:?}");
+    if ranges_0.len() < 2 {
+        ranges_1
+    } else {
+        ranges_0
+    }
 }
 
 #[test]

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -8,7 +8,7 @@ use lsp_types::Position;
 use chialisp::compiler::compiler::DefaultCompilerOpts;
 use chialisp::compiler::comptypes::{
     Binding, BindingPattern, BodyForm, CompileErr, CompileForm, Export, FrontendOutput, HelperForm,
-    LetData, LetFormKind,
+    LetData, LetFormKind, NamespaceRefData,
 };
 #[cfg(test)]
 use chialisp::compiler::frontend::frontend;
@@ -21,6 +21,12 @@ use crate::lsp::types::{
     DocData, DocPosition, DocRange, Hash, IncludeData, ParseScope, ReparsedExp, ReparsedHelper,
     ScopeKind,
 };
+
+#[derive(Debug, Clone)]
+pub enum IncludedFileSpec {
+    Include(IncludeData),
+    Import(NamespaceRefData),
+}
 
 #[derive(Debug, Clone)]
 // A parsed document.
@@ -43,7 +49,7 @@ pub struct ParsedDoc {
     // If present, the main expression in ReparsedExp form.
     pub exp: Option<ReparsedExp>,
     // Includes in the various files, indexed by included file.
-    pub includes: HashMap<Hash, IncludeData>,
+    pub includes: HashMap<Hash, IncludedFileSpec>,
     // Index of hashed ranges (as Reparsed* data) to the names they bind.
     pub hash_to_name: HashMap<Hash, Vec<u8>>,
     // Chialisp frontend errors encountered while parsing.
@@ -876,6 +882,8 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> (bool, Vec<DocRange>) {
     let mut level = 0;
     let mut line = 0;
     let mut character = 0;
+    let mut first_range = true;
+    let mut first_word_of_module = Vec::new();
 
     for i in DocVecByteIter::new(srctext) {
         if i == b';' {
@@ -897,6 +905,10 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> (bool, Vec<DocRange>) {
             }
             character += 1;
         } else if i == b')' {
+            // First range is over.  This is watching for
+            // (import , (defun , etc.
+            first_range = false;
+
             // We expect to contain only one toplevel list, so other ends
             // are probably a misparse.
             if !in_comment && level > 0 {
@@ -929,13 +941,32 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> (bool, Vec<DocRange>) {
             }
             character += 1;
         } else {
+            if level == 1 && first_word_of_module.len() < 20 {
+                first_word_of_module.push(i);
+            }
             character += 1;
         }
     }
 
-    eprintln!("ranges_0 {ranges_0:?}");
-    eprintln!("ranges_1 {ranges_1:?}");
-    if ranges_0.len() < 2 {
+    // XXX improve this detection.
+    // Module style should match when there's 1 range if:
+    // The single form starts with 'export' or a word that begins a helper:
+    // embed, import, defconst, defconstant, defun, defun-inline, defmacro
+
+    let first_word: Vec<u8> = first_word_of_module.iter().take_while(|c| **c >= b'a' && **c <= b'z' || **c == b'-').copied().collect();
+    let is_module_form = [
+        "defconst",
+        "defconstant",
+        "defmac",
+        "defmacro",
+        "defun",
+        "defun-inline",
+        "embed",
+        "export",
+        "import"
+    ].iter().find(|w| w.as_bytes() == first_word).is_some();
+
+    if ranges_0.len() == 1 && !is_module_form {
         (false, ranges_1)
     } else {
         (true, ranges_0)

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -40,7 +40,7 @@ pub struct ParsedDoc {
     // chialisp in many different tools deriving from chialisp.
     pub compiled: CompileForm,
     // Exports if module style.
-    pub exports: Vec<Export>,
+    pub exports: HashMap<Hash, Export>,
     // The scope stack for this file.
     pub scopes: ParseScope,
     // Helpers in ReparsedHelper form.  We pulled these indiviually by identifying
@@ -72,7 +72,6 @@ impl ParsedDoc {
                 helpers: Default::default(),
                 exp: Rc::new(BodyForm::Quoted(nil)),
             },
-            exports: Vec::default(),
             scopes: ParseScope {
                 region: startloc,
                 kind: ScopeKind::Module,
@@ -81,6 +80,7 @@ impl ParsedDoc {
                 containing: Default::default(),
             },
             helpers: Default::default(),
+            exports: Default::default(),
             exp: None,
             includes: Default::default(),
             hash_to_name: Default::default(),

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -953,7 +953,11 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> (bool, Vec<DocRange>) {
     // The single form starts with 'export' or a word that begins a helper:
     // embed, import, defconst, defconstant, defun, defun-inline, defmacro
 
-    let first_word: Vec<u8> = first_word_of_module.iter().take_while(|c| **c >= b'a' && **c <= b'z' || **c == b'-').copied().collect();
+    let first_word: Vec<u8> = first_word_of_module
+        .iter()
+        .take_while(|c| **c >= b'a' && **c <= b'z' || **c == b'-')
+        .copied()
+        .collect();
     let is_module_form = [
         "defconst",
         "defconstant",
@@ -963,8 +967,11 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> (bool, Vec<DocRange>) {
         "defun-inline",
         "embed",
         "export",
-        "import"
-    ].iter().find(|w| w.as_bytes() == first_word).is_some();
+        "import",
+    ]
+    .iter()
+    .find(|w| w.as_bytes() == first_word)
+    .is_some();
 
     if ranges_0.len() == 1 && !is_module_form {
         (false, ranges_1)
@@ -986,57 +993,60 @@ fn test_make_simple_ranges_1() {
     ];
     assert_eq!(
         make_simple_ranges(test_data),
-        (false, vec![
-            DocRange {
-                start: DocPosition {
-                    line: 0,
-                    character: 2
+        (
+            false,
+            vec![
+                DocRange {
+                    start: DocPosition {
+                        line: 0,
+                        character: 2
+                    },
+                    end: DocPosition {
+                        line: 0,
+                        character: 8
+                    }
                 },
-                end: DocPosition {
-                    line: 0,
-                    character: 8
-                }
-            },
-            DocRange {
-                start: DocPosition {
-                    line: 0,
-                    character: 9
+                DocRange {
+                    start: DocPosition {
+                        line: 0,
+                        character: 9
+                    },
+                    end: DocPosition {
+                        line: 0,
+                        character: 16
+                    }
                 },
-                end: DocPosition {
-                    line: 0,
-                    character: 16
-                }
-            },
-            DocRange {
-                start: DocPosition {
-                    line: 2,
-                    character: 3
+                DocRange {
+                    start: DocPosition {
+                        line: 2,
+                        character: 3
+                    },
+                    end: DocPosition {
+                        line: 3,
+                        character: 40
+                    }
                 },
-                end: DocPosition {
-                    line: 3,
-                    character: 40
-                }
-            },
-            DocRange {
-                start: DocPosition {
-                    line: 4,
-                    character: 0
+                DocRange {
+                    start: DocPosition {
+                        line: 4,
+                        character: 0
+                    },
+                    end: DocPosition {
+                        line: 4,
+                        character: 10
+                    }
                 },
-                end: DocPosition {
-                    line: 4,
-                    character: 10
+                DocRange {
+                    start: DocPosition {
+                        line: 5,
+                        character: 2
+                    },
+                    end: DocPosition {
+                        line: 5,
+                        character: 4
+                    }
                 }
-            },
-            DocRange {
-                start: DocPosition {
-                    line: 5,
-                    character: 2
-                },
-                end: DocPosition {
-                    line: 5,
-                    character: 4
-                }
-            }
-        ])
+            ]
+        )
     );
 }

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -7,7 +7,8 @@ use lsp_types::Position;
 #[cfg(test)]
 use chialisp::compiler::compiler::DefaultCompilerOpts;
 use chialisp::compiler::comptypes::{
-    Binding, BindingPattern, BodyForm, CompileErr, CompileForm, HelperForm, LetData, LetFormKind,
+    Binding, BindingPattern, BodyForm, CompileErr, CompileForm, FrontendOutput, HelperForm,
+    LetData, LetFormKind,
 };
 #[cfg(test)]
 use chialisp::compiler::frontend::frontend;
@@ -122,6 +123,12 @@ pub fn recover_scopes(ourfile: &str, text: &[Rc<Vec<u8>>], fe: &CompileForm) -> 
 
     for h in fe.helpers.iter() {
         match h {
+            HelperForm::Defnamespace(_) => {
+                // XXX
+            }
+            HelperForm::Defnsref(_) => {
+                // XXX
+            }
             HelperForm::Defun(_, d) => {
                 toplevel_funs.insert(Rc::new(SExp::Atom(d.loc.clone(), d.name.clone())));
             }
@@ -393,10 +400,10 @@ fn test_not_is_first_in_list_next_word() {
 }
 
 // Given a position, return the identifier at that position.  Relies on find_ident.
-pub fn get_positional_text(text: &[Rc<Vec<u8>>], position: &Position) -> Option<Vec<u8>> {
+pub fn get_positional_text(lines: &DocData, position: &Position) -> Option<Vec<u8>> {
     let pl = position.line as usize;
-    if pl < text.len() {
-        let line = text[pl].clone();
+    if pl < lines.text.len() {
+        let line = lines.text[pl].clone();
         find_ident(line, position.character)
     } else {
         None
@@ -408,7 +415,7 @@ fn test_get_positional_text() {
     let simple_doc = make_simple_test_doc_data_from_lines("test.clsp", &["(", "  hi there", ")"]);
     assert_eq!(
         get_positional_text(
-            &simple_doc.text,
+            &simple_doc,
             &Position {
                 line: 1,
                 character: 3
@@ -588,7 +595,7 @@ fn make_helper_scope(h: &HelperForm) -> Option<ParseScope> {
 }
 
 #[cfg(test)]
-fn get_test_program_for_scope_tests(file: &str, prog: &[Rc<Vec<u8>>]) -> CompileForm {
+fn get_test_program_for_scope_tests(file: &str, prog: &[Rc<Vec<u8>>]) -> FrontendOutput {
     let sl = Srcloc::start(file);
     let parsed = parse_sexp(sl, DocVecByteIter::new(prog)).expect("should parse");
     let opts = Rc::new(DefaultCompilerOpts::new(file));
@@ -596,15 +603,16 @@ fn get_test_program_for_scope_tests(file: &str, prog: &[Rc<Vec<u8>>]) -> Compile
 }
 
 #[cfg(test)]
-fn make_test_program_scope(file: &str, prog: &[Rc<Vec<u8>>]) -> (CompileForm, ParseScope) {
+fn make_test_program_scope(file: &str, prog: &[Rc<Vec<u8>>]) -> (FrontendOutput, ParseScope) {
     let compiled = get_test_program_for_scope_tests(file, prog);
     (
         compiled.clone(),
         ParseScope {
-            region: compiled.loc.clone(),
+            region: compiled.compileform().loc.clone(),
             kind: ScopeKind::Module,
             variables: Default::default(),
             functions: compiled
+                .compileform()
                 .helpers
                 .iter()
                 .filter_map(|h| {
@@ -618,6 +626,7 @@ fn make_test_program_scope(file: &str, prog: &[Rc<Vec<u8>>]) -> (CompileForm, Pa
                 })
                 .collect(),
             containing: compiled
+                .compileform()
                 .helpers
                 .iter()
                 .filter_map(|h| make_helper_scope(&h))
@@ -640,13 +649,15 @@ fn make_scope_stack_simple() {
     let (compiled, program_scope) = make_test_program_scope(file, &doc.text);
     assert_eq!(program_scope.functions.len(), 2);
     assert_eq!(program_scope.containing.len(), 2);
-    assert!(program_scope
-        .functions
-        .contains(&SExp::atom_from_string(compiled.loc.clone(), "test1")));
-    assert!(program_scope
-        .functions
-        .contains(&SExp::atom_from_string(compiled.loc.clone(), "test2")));
-    let filename_rc = compiled.loc.file.clone();
+    assert!(program_scope.functions.contains(&SExp::atom_from_string(
+        compiled.compileform().loc.clone(),
+        "test1"
+    )));
+    assert!(program_scope.functions.contains(&SExp::atom_from_string(
+        compiled.compileform().loc.clone(),
+        "test2"
+    )));
+    let filename_rc = compiled.compileform().loc.file.clone();
     assert_eq!(
         program_scope.containing[0].region,
         Srcloc::new(filename_rc.clone(), 2, 3).ext(&Srcloc::new(filename_rc.clone(), 2, 25))
@@ -663,7 +674,7 @@ fn make_scope_stack_simple() {
     for v in program_scope.containing[1].containing[0].variables.iter() {
         let vrange = DocRange::from_srcloc(v.loc()).to_range();
         assert_eq!(
-            get_positional_text(&doc.text, &vrange.start),
+            get_positional_text(&doc, &vrange.start),
             Some(b"C".to_vec())
         );
     }

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -867,7 +867,7 @@ fn test_make_arg_set() {
 //
 // In module style, there is no outside container.  We should detect which the
 // source file is and act accordingly.
-pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> Vec<DocRange> {
+pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> (bool, Vec<DocRange>) {
     let mut ranges_1 = Vec::new();
     let mut ranges_0 = Vec::new();
     let mut in_comment = false;
@@ -936,9 +936,9 @@ pub fn make_simple_ranges(srctext: &[Rc<Vec<u8>>]) -> Vec<DocRange> {
     eprintln!("ranges_0 {ranges_0:?}");
     eprintln!("ranges_1 {ranges_1:?}");
     if ranges_0.len() < 2 {
-        ranges_1
+        (false, ranges_1)
     } else {
-        ranges_0
+        (true, ranges_0)
     }
 }
 
@@ -955,7 +955,7 @@ fn test_make_simple_ranges_1() {
     ];
     assert_eq!(
         make_simple_ranges(test_data),
-        vec![
+        (false, vec![
             DocRange {
                 start: DocPosition {
                     line: 0,
@@ -1006,6 +1006,6 @@ fn test_make_simple_ranges_1() {
                     character: 4
                 }
             }
-        ]
+        ])
     );
 }

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -5,11 +5,11 @@ use std::rc::Rc;
 use crate::lsp::completion::PRIM_NAMES;
 use crate::lsp::parse::{grab_scope_doc_range, recover_scopes, ParsedDoc};
 use crate::lsp::types::{
-    DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParseScope, ReparsedExp, ReparsedHelper,
+    DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParsedForm, ParseScope, ReparsedExp, ReparsedHelper,
 };
 use chialisp::compiler::clvm::{sha256tree, sha256tree_from_atom};
-use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm};
-use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult};
+use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, Export, HelperForm};
+use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult, match_export_form};
 use chialisp::compiler::prims::primquote;
 use chialisp::compiler::sexp::{enlist, parse_sexp, SExp};
 use chialisp::compiler::srcloc::Srcloc;
@@ -97,10 +97,10 @@ pub fn parse_include(sexp: Rc<SExp>) -> Option<IncludeData> {
     })
 }
 
-fn compile_helperform_with_loose_defconstant(
+fn compile_helperform_with_loose_defconstant_and_module_forms(
     opts: Rc<dyn CompilerOpts>,
     parsed: Rc<SExp>,
-) -> Result<Option<HelperFormResult>, CompileErr> {
+) -> Result<Option<ParsedForm<HelperFormResult>>, CompileErr> {
     let is_defconstant = |sexp: &SExp| {
         if let SExp::Atom(_, name) = sexp {
             return name == b"defconstant";
@@ -129,13 +129,21 @@ fn compile_helperform_with_loose_defconstant(
                 // Try by enwrapping the body in quote so it can act as an
                 // expression to the parser.  Other kinds of errors will still
                 // go through.
-                return compile_helperform(opts, Rc::new(amended_instr));
+                return compile_helperform(opts.clone(), Rc::new(amended_instr)).map(|o| o.map(ParsedForm::Helper));
             }
         }
     }
 
     // Not a proper list so not the kind of thing we're looking for.
-    compile_helperform(opts, parsed)
+    match compile_helperform(opts.clone(), parsed.clone()).map(|o| o.filter(|h| !h.new_helpers.is_empty()).map(ParsedForm::Helper)) {
+        Err(e) => {
+            match_export_form(
+                opts.clone(),
+                parsed.clone()).map(|o| o.map(ParsedForm::ModuleExport)
+            ).map_err(|_| e)
+        }
+        r => r
+    }
 }
 
 pub fn reparse_subset(
@@ -354,7 +362,7 @@ pub fn reparse_subset(
                                         ReparsedHelper {
                                             hash: new_hash,
                                             range: r.clone(),
-                                            parsed: Ok(h.clone()),
+                                            parsed: Ok(ParsedForm::Helper(h.clone())),
                                         },
                                     );
                                 }
@@ -384,7 +392,7 @@ pub fn reparse_subset(
                     };
 
                     let dc_result =
-                        compile_helperform_with_loose_defconstant(opts.clone(), parsed[0].clone())
+                        compile_helperform_with_loose_defconstant_and_module_forms(opts.clone(), parsed[0].clone())
                             .and_then(|mh| {
                                 if let Some(h) = mh {
                                     Ok(h)
@@ -393,17 +401,27 @@ pub fn reparse_subset(
                                 }
                             });
                     match dc_result {
-                        Ok(res) => {
+                        Ok(ParsedForm::Helper(res)) => {
                             if let Some(h) = res.new_helpers.iter().next() {
                                 result.helpers.insert(
                                     hash.clone(),
                                     ReparsedHelper {
                                         hash,
                                         range: r.clone(),
-                                        parsed: Ok(h.clone()),
+                                        parsed: Ok(ParsedForm::Helper(h.clone())),
                                     },
                                 );
                             }
+                        }
+                        Ok(ParsedForm::ModuleExport(res)) => {
+                            result.helpers.insert(
+                                hash.clone(),
+                                ReparsedHelper {
+                                    hash,
+                                    range: r.clone(),
+                                    parsed: Ok(ParsedForm::ModuleExport(res.clone()))
+                                },
+                            );
                         }
                         Err(e) => {
                             result.helpers.insert(
@@ -550,6 +568,7 @@ pub fn combine_new_with_old_parse(
     let new_includes = reparse.includes.clone();
     let mut new_helpers = parsed.helpers.clone();
     let mut extracted_helpers = Vec::new();
+    let mut exports = Vec::new();
     let mut to_remove = HashSet::new();
     let mut remove_names = HashSet::new();
     let mut hash_to_name = parsed.hash_to_name.clone();
@@ -584,9 +603,12 @@ pub fn combine_new_with_old_parse(
             Err(e) => {
                 out_errors.push(e.clone());
             }
-            Ok(parsed) => {
+            Ok(ParsedForm::Helper(parsed)) => {
                 hash_to_name.insert(h.clone(), parsed.name().clone());
                 extracted_helpers.push(parsed.clone());
+            }
+            Ok(ParsedForm::ModuleExport(parsed)) => {
+                exports.push(parsed.clone());
             }
         }
         new_helpers.insert(h.clone(), p.clone());
@@ -636,6 +658,7 @@ pub fn combine_new_with_old_parse(
         ignored: reparse.ignored,
         mod_kw: reparse.mod_kw.clone(),
         compiled: compile_with_dead_helpers_removed,
+        exports,
         errors: out_errors,
         scopes,
         includes: new_includes,

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -7,11 +7,9 @@ use crate::lsp::parse::{grab_scope_doc_range, recover_scopes, ParsedDoc};
 use crate::lsp::types::{
     DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParseScope, ReparsedExp, ReparsedHelper,
 };
-use chialisp::compiler::clvm::sha256tree_from_atom;
-use chialisp::compiler::comptypes::{
-    BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm,
-};
-use chialisp::compiler::frontend::{compile_bodyform, compile_helperform};
+use chialisp::compiler::clvm::{sha256tree, sha256tree_from_atom};
+use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm};
+use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult};
 use chialisp::compiler::prims::primquote;
 use chialisp::compiler::sexp::{enlist, parse_sexp, SExp};
 use chialisp::compiler::srcloc::Srcloc;
@@ -102,7 +100,7 @@ pub fn parse_include(sexp: Rc<SExp>) -> Option<IncludeData> {
 fn compile_helperform_with_loose_defconstant(
     opts: Rc<dyn CompilerOpts>,
     parsed: Rc<SExp>,
-) -> Result<Option<HelperForm>, CompileErr> {
+) -> Result<Option<HelperFormResult>, CompileErr> {
     let is_defconstant = |sexp: &SExp| {
         if let SExp::Atom(_, name) = sexp {
             return name == b"defconstant";
@@ -341,24 +339,83 @@ pub fn reparse_subset(
                         continue;
                     }
 
-                    result.helpers.insert(
-                        hash.clone(),
-                        ReparsedHelper {
-                            hash,
-                            range: r.clone(),
-                            parsed: compile_helperform_with_loose_defconstant(
-                                opts.clone(),
-                                parsed[0].clone(),
-                            )
+                    let compiled_result = compile_helperform(opts.clone(), parsed[0].clone());
+
+                    let parsed_result_to_record = match compiled_result {
+                        Ok(Some(parsed)) => {
+                            let typedefs: Vec<&HelperForm> = vec![];
+                            let other_helpers: &[HelperForm] = &parsed.new_helpers;
+
+                            let use_helper = if !typedefs.is_empty() {
+                                for h in other_helpers.into_iter() {
+                                    let new_hash = Hash::new(&sha256tree(h.to_sexp()));
+                                    result.helpers.insert(
+                                        new_hash.clone(),
+                                        ReparsedHelper {
+                                            hash: new_hash,
+                                            range: r.clone(),
+                                            parsed: Ok(h.clone()),
+                                        },
+                                    );
+                                }
+                                Some(typedefs[0])
+                            } else if !parsed.new_helpers.is_empty() {
+                                Some(&parsed.new_helpers[0])
+                            } else {
+                                None
+                            };
+
+                            let new_parsed = if let Some(h) = use_helper {
+                                Ok(h)
+                            } else {
+                                Err(CompileErr(
+                                    loc.clone(),
+                                    "helper form was parsed but it wasn't understood by the LSP"
+                                        .to_string(),
+                                ))
+                            };
+
+                            new_parsed.cloned()
+                        }
+                        Ok(None) => {
+                            Err(CompileErr(loc.clone(), "must be a helper form".to_string()))
+                        }
+                        Err(e) => Err(e),
+                    };
+
+                    let dc_result =
+                        compile_helperform_with_loose_defconstant(opts.clone(), parsed[0].clone())
                             .and_then(|mh| {
                                 if let Some(h) = mh {
                                     Ok(h)
                                 } else {
                                     Err(CompileErr(loc, "must be a helper form".to_string()))
                                 }
-                            }),
-                        },
-                    );
+                            });
+                    match dc_result {
+                        Ok(res) => {
+                            if let Some(h) = res.new_helpers.iter().next() {
+                                result.helpers.insert(
+                                    hash.clone(),
+                                    ReparsedHelper {
+                                        hash,
+                                        range: r.clone(),
+                                        parsed: Ok(h.clone()),
+                                    },
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            result.helpers.insert(
+                                hash.clone(),
+                                ReparsedHelper {
+                                    hash,
+                                    range: r.clone(),
+                                    parsed: Err(e),
+                                },
+                            );
+                        }
+                    }
                 }
                 Err((l, s)) => {
                     result.helpers.insert(

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -151,6 +151,7 @@ pub fn reparse_subset(
     opts: Rc<dyn CompilerOpts>,
     doc: &[Rc<Vec<u8>>],
     uristring: &str,
+    module_style: bool,
     simple_ranges: &[DocRange],
     compiled: &CompileForm,
     prev_helpers: &HashMap<Hash, ReparsedHelper>,
@@ -260,7 +261,7 @@ pub fn reparse_subset(
         }
     }
 
-    if break_end == suffix_text.len() {
+    if break_end == suffix_text.len() && !module_style {
         result.errors.push(CompileErr(
             DocRange {
                 start: suffix_start.clone(),

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -3,13 +3,18 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::lsp::completion::PRIM_NAMES;
-use crate::lsp::parse::{grab_scope_doc_range, recover_scopes, ParsedDoc, IncludedFileSpec};
+use crate::lsp::parse::{grab_scope_doc_range, recover_scopes, IncludedFileSpec, ParsedDoc};
 use crate::lsp::types::{
-    DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParsedForm, ParseScope, ReparsedExp, ReparsedHelper,
+    DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParseScope, ParsedForm, ReparsedExp,
+    ReparsedHelper,
 };
 use chialisp::compiler::clvm::{sha256tree, sha256tree_from_atom};
-use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, Export, HelperForm, NamespaceRefData};
-use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult, match_export_form};
+use chialisp::compiler::comptypes::{
+    BodyForm, CompileErr, CompileForm, CompilerOpts, Export, HelperForm, NamespaceRefData,
+};
+use chialisp::compiler::frontend::{
+    compile_bodyform, compile_helperform, match_export_form, HelperFormResult,
+};
 use chialisp::compiler::prims::primquote;
 use chialisp::compiler::sexp::{enlist, parse_sexp, SExp};
 use chialisp::compiler::srcloc::Srcloc;
@@ -129,20 +134,21 @@ fn compile_helperform_with_loose_defconstant_and_module_forms(
                 // Try by enwrapping the body in quote so it can act as an
                 // expression to the parser.  Other kinds of errors will still
                 // go through.
-                return compile_helperform(opts.clone(), Rc::new(amended_instr)).map(|o| o.map(ParsedForm::Helper));
+                return compile_helperform(opts.clone(), Rc::new(amended_instr))
+                    .map(|o| o.map(ParsedForm::Helper));
             }
         }
     }
 
     // Not a proper list so not the kind of thing we're looking for.
-    match compile_helperform(opts.clone(), parsed.clone()).map(|o| o.filter(|h| !h.new_helpers.is_empty()).map(ParsedForm::Helper)) {
-        Err(e) => {
-            match_export_form(
-                opts.clone(),
-                parsed.clone()).map(|o| o.map(ParsedForm::ModuleExport)
-            ).map_err(|_| e)
-        }
-        r => r
+    match compile_helperform(opts.clone(), parsed.clone()).map(|o| {
+        o.filter(|h| !h.new_helpers.is_empty())
+            .map(ParsedForm::Helper)
+    }) {
+        Err(e) => match_export_form(opts.clone(), parsed.clone())
+            .map(|o| o.map(ParsedForm::ModuleExport))
+            .map_err(|_| e),
+        r => r,
     }
 }
 
@@ -344,7 +350,9 @@ pub fn reparse_subset(
                         });
                         continue;
                     } else if let Some(include) = parse_include(parsed[0].clone()) {
-                        result.includes.insert(hash, IncludedFileSpec::Include(include.clone()));
+                        result
+                            .includes
+                            .insert(hash, IncludedFileSpec::Include(include.clone()));
                         continue;
                     }
 
@@ -392,21 +400,26 @@ pub fn reparse_subset(
                         Err(e) => Err(e),
                     };
 
-                    let dc_result =
-                        compile_helperform_with_loose_defconstant_and_module_forms(opts.clone(), parsed[0].clone())
-                            .and_then(|mh| {
-                                if let Some(h) = mh {
-                                    Ok(h)
-                                } else {
-                                    Err(CompileErr(loc, "must be a helper form".to_string()))
-                                }
-                            });
+                    let dc_result = compile_helperform_with_loose_defconstant_and_module_forms(
+                        opts.clone(),
+                        parsed[0].clone(),
+                    )
+                    .and_then(|mh| {
+                        if let Some(h) = mh {
+                            Ok(h)
+                        } else {
+                            Err(CompileErr(loc, "must be a helper form".to_string()))
+                        }
+                    });
                     match dc_result {
                         Ok(ParsedForm::Helper(res)) => {
                             if let Some(h) = res.new_helpers.iter().next() {
                                 if let HelperForm::Defnsref(import) = h {
                                     let nsref: &NamespaceRefData = import.borrow();
-                                    result.includes.insert(hash.clone(), IncludedFileSpec::Import(nsref.clone()));
+                                    result.includes.insert(
+                                        hash.clone(),
+                                        IncludedFileSpec::Import(nsref.clone()),
+                                    );
                                 }
                                 result.helpers.insert(
                                     hash.clone(),
@@ -425,7 +438,7 @@ pub fn reparse_subset(
                                 ReparsedHelper {
                                     hash,
                                     range: r.clone(),
-                                    parsed: Ok(ParsedForm::ModuleExport(res.clone()))
+                                    parsed: Ok(ParsedForm::ModuleExport(res.clone())),
                                 },
                             );
                         }

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -350,7 +350,7 @@ pub fn reparse_subset(
 
                     let compiled_result = compile_helperform(opts.clone(), parsed[0].clone());
 
-                    let parsed_result_to_record = match compiled_result {
+                    let _ = match compiled_result {
                         Ok(Some(parsed)) => {
                             let typedefs: Vec<&HelperForm> = vec![];
                             let other_helpers: &[HelperForm] = &parsed.new_helpers;
@@ -419,6 +419,7 @@ pub fn reparse_subset(
                             }
                         }
                         Ok(ParsedForm::ModuleExport(res)) => {
+                            eprintln!("export res {res:?}");
                             result.helpers.insert(
                                 hash.clone(),
                                 ReparsedHelper {
@@ -573,7 +574,7 @@ pub fn combine_new_with_old_parse(
     let new_includes = reparse.includes.clone();
     let mut new_helpers = parsed.helpers.clone();
     let mut extracted_helpers = Vec::new();
-    let mut exports = Vec::new();
+    let mut exports = parsed.exports.clone();
     let mut to_remove = HashSet::new();
     let mut remove_names = HashSet::new();
     let mut hash_to_name = parsed.hash_to_name.clone();
@@ -600,6 +601,7 @@ pub fn combine_new_with_old_parse(
     for h in to_remove.iter() {
         hash_to_name.remove(h);
         new_helpers.remove(h);
+        exports.remove(h);
     }
 
     // Iterate new helpers.
@@ -611,12 +613,20 @@ pub fn combine_new_with_old_parse(
             Ok(ParsedForm::Helper(parsed)) => {
                 hash_to_name.insert(h.clone(), parsed.name().clone());
                 extracted_helpers.push(parsed.clone());
+                new_helpers.insert(h.clone(), p.clone());
             }
-            Ok(ParsedForm::ModuleExport(parsed)) => {
-                exports.push(parsed.clone());
+            Ok(ParsedForm::ModuleExport(Export::MainProgram(p))) => {
+                let name = b"__export__main".to_vec();
+                hash_to_name.insert(h.clone(), name.clone());
+                exports.insert(h.clone(), Export::MainProgram(p.clone()));
+            }
+            Ok(ParsedForm::ModuleExport(Export::Function(f))) => {
+                let mut name = b"__export__".to_vec();
+                name.append(&mut f.name.value.clone());
+                hash_to_name.insert(h.clone(), name.clone());
+                exports.insert(h.clone(), Export::Function(f.clone()));
             }
         }
-        new_helpers.insert(h.clone(), p.clone());
     }
 
     // For helpers that parsed, replace them in the compile.

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -3,12 +3,12 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::lsp::completion::PRIM_NAMES;
-use crate::lsp::parse::{grab_scope_doc_range, recover_scopes, ParsedDoc};
+use crate::lsp::parse::{grab_scope_doc_range, recover_scopes, ParsedDoc, IncludedFileSpec};
 use crate::lsp::types::{
     DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParsedForm, ParseScope, ReparsedExp, ReparsedHelper,
 };
 use chialisp::compiler::clvm::{sha256tree, sha256tree_from_atom};
-use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, Export, HelperForm};
+use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, Export, HelperForm, NamespaceRefData};
 use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult, match_export_form};
 use chialisp::compiler::prims::primquote;
 use chialisp::compiler::sexp::{enlist, parse_sexp, SExp};
@@ -25,7 +25,7 @@ pub struct ReparsedModule {
     pub helpers: HashMap<Hash, ReparsedHelper>,
     pub exp: Option<ReparsedExp>,
     pub unparsed: HashMap<Hash, DocRange>,
-    pub includes: HashMap<Hash, IncludeData>,
+    pub includes: HashMap<Hash, IncludedFileSpec>,
     pub errors: Vec<CompileErr>,
 }
 
@@ -344,7 +344,7 @@ pub fn reparse_subset(
                         });
                         continue;
                     } else if let Some(include) = parse_include(parsed[0].clone()) {
-                        result.includes.insert(hash, include.clone());
+                        result.includes.insert(hash, IncludedFileSpec::Include(include.clone()));
                         continue;
                     }
 
@@ -404,6 +404,10 @@ pub fn reparse_subset(
                     match dc_result {
                         Ok(ParsedForm::Helper(res)) => {
                             if let Some(h) = res.new_helpers.iter().next() {
+                                if let HelperForm::Defnsref(import) = h {
+                                    let nsref: &NamespaceRefData = import.borrow();
+                                    result.includes.insert(hash.clone(), IncludedFileSpec::Import(nsref.clone()));
+                                }
                                 result.helpers.insert(
                                     hash.clone(),
                                     ReparsedHelper {

--- a/wasm/src/lsp/resolve.rs
+++ b/wasm/src/lsp/resolve.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use chialisp::compiler::comptypes::{CompileForm, HelperForm, LongNameTranslation, ModuleImportSpec};
+use chialisp::compiler::comptypes::{CompileForm, HelperForm, ImportLongName, LongNameTranslation, ModuleImportSpec, NamespaceRefData};
 use chialisp::compiler::sexp::decode_string;
 use chialisp::compiler::srcloc::Srcloc;
 
@@ -18,28 +18,57 @@ pub trait HelperResolver {
     ) -> Option<HelperForm>;
 }
 
-fn resolve_imported_name(spec: &ModuleImportSpec, called_name: &[u8]) -> Option<Vec<u8>> {
-    match spec {
-        ModuleImportSpec::Qualified(_) => None,
-        ModuleImportSpec::Exposing(_, exposed_names) => {
-            for exposed_name in exposed_names.iter() {
-                let available_name = exposed_name.alias.as_ref().unwrap_or(&exposed_name.name);
-                if available_name == called_name {
-                    return Some(exposed_name.name.clone());
+fn get_filename_of_import(longname: &ImportLongName) -> String {
+    let imported_filename = longname
+        .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+    decode_string(&imported_filename)
+}
+
+fn resolve_imported_name(
+    service_provider: &mut LSPServiceProvider,
+    namespace_ref: &NamespaceRefData,
+    called_name: &[u8]
+) -> Option<(String, Vec<u8>)> {
+    match &namespace_ref.specification {
+        ModuleImportSpec::Qualified(q) => {
+            let filename_decoded = get_filename_of_import(&q.name);
+            if let Some((file_uri, parsed)) = service_provider.get_file_uri_and_ensure_parsing(&filename_decoded) {
+                let qualified_parent = q.target.as_ref().map(|q| &q.name).unwrap_or_else(|| &q.name);
+                for helper in parsed.compiled.helpers.iter() {
+                    let full_helper_qualified_name = qualified_parent.with_child(helper.name());
+                    let name_to_match = full_helper_qualified_name.as_u8_vec(LongNameTranslation::Namespace);
+                    if name_to_match == called_name {
+                        return Some((file_uri, helper.name().to_vec()));
+                    }
                 }
             }
-            None
+        }
+        ModuleImportSpec::Exposing(_, exposed_names) => {
+            let filename_decoded = get_filename_of_import(&namespace_ref.longname);
+            if let Some((file_uri, parsed)) = service_provider.get_file_uri_and_ensure_parsing(&filename_decoded) {
+                for exposed_name in exposed_names.iter() {
+                    let available_name = exposed_name.alias.as_ref().unwrap_or(&exposed_name.name);
+                    if available_name == called_name {
+                        return Some((file_uri, exposed_name.name.clone()));
+                    }
+                }
+            }
         }
         ModuleImportSpec::Hiding(_, hidden_names) => {
-            for hidden_name in hidden_names.iter() {
-                let hidden = hidden_name.alias.as_ref().unwrap_or(&hidden_name.name);
-                if hidden == called_name {
-                    return None;
+            let filename_decoded = get_filename_of_import(&namespace_ref.longname);
+            if let Some((file_uri, parsed)) = service_provider.get_file_uri_and_ensure_parsing(&filename_decoded) {
+                for hidden_name in hidden_names.iter() {
+                    let hidden = hidden_name.alias.as_ref().unwrap_or(&hidden_name.name);
+                    if hidden == called_name {
+                        return None;
+                    }
                 }
+                return Some((file_uri, called_name.to_vec()));
             }
-            Some(called_name.to_vec())
         }
     }
+
+    None
 }
 
 impl HelperResolver for LSPServiceProvider {
@@ -54,41 +83,20 @@ impl HelperResolver for LSPServiceProvider {
                 _ => continue,
             };
 
-            let Some(imported_name) = resolve_imported_name(&nsref.specification, name) else {
+            let Some((file_uri, imported_name)) = resolve_imported_name(self, &nsref, name) else {
                 continue;
             };
 
-            let imported_filename = nsref
-                .longname
-                .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
-            let imported_filename_decoded = decode_string(&imported_filename);
-
-            if let Ok((filename, file_body)) = get_file_content(
-                self.log.clone(),
-                self.fs.clone(),
-                self.get_workspace_root(),
-                &self.config.include_paths,
-                &decode_string(&imported_filename),
-            ) {
-                if let Some(file_uri) = self
-                    .get_workspace_root()
-                    .and_then(|r| r.join(&filename).to_str().map(urlify))
-                {
-                    self.save_doc(file_uri.clone(), file_body);
-                    self.ensure_parsed_document(&file_uri);
-
-                    if let Some(imported_doc) = self.get_parsed(&file_uri) {
-                        for imported_helper in imported_doc.compiled.helpers.iter() {
-                            match imported_helper {
-                                HelperForm::Defun(_, defun) if defun.name == imported_name => {
-                                    return Some(imported_helper.clone());
-                                }
-                                HelperForm::Defmacro(mac) if mac.name == imported_name => {
-                                    return Some(imported_helper.clone());
-                                }
-                                _ => {}
-                            }
+            if let Some(imported_doc) = self.get_parsed(&file_uri) {
+                for imported_helper in imported_doc.compiled.helpers.iter() {
+                    match imported_helper {
+                        HelperForm::Defun(_, defun) if defun.name == imported_name => {
+                            return Some(imported_helper.clone());
                         }
+                        HelperForm::Defmacro(mac) if mac.name == imported_name => {
+                            return Some(imported_helper.clone());
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/wasm/src/lsp/resolve.rs
+++ b/wasm/src/lsp/resolve.rs
@@ -1,0 +1,108 @@
+use std::path::Path;
+
+use chialisp::compiler::comptypes::{CompileForm, HelperForm, LongNameTranslation, ModuleImportSpec};
+use chialisp::compiler::sexp::decode_string;
+use chialisp::compiler::srcloc::Srcloc;
+
+use crate::lsp::compopts::get_file_content;
+use crate::lsp::parse::ParsedDoc;
+use crate::lsp::semtok::{DocumentProcessingDescription, SemanticTokenSortable};
+use crate::lsp::types::{TK_FUNCTION_IDX, TK_MACRO_IDX, urlify};
+use crate::lsp::LSPServiceProvider;
+
+pub trait HelperResolver {
+    fn resolve_helper_reference<'a>(
+        &mut self,
+        frontend: &CompileForm,
+        name: &[u8],
+    ) -> Option<HelperForm>;
+}
+
+fn resolve_imported_name(spec: &ModuleImportSpec, called_name: &[u8]) -> Option<Vec<u8>> {
+    match spec {
+        ModuleImportSpec::Qualified(_) => None,
+        ModuleImportSpec::Exposing(_, exposed_names) => {
+            for exposed_name in exposed_names.iter() {
+                let available_name = exposed_name.alias.as_ref().unwrap_or(&exposed_name.name);
+                if available_name == called_name {
+                    return Some(exposed_name.name.clone());
+                }
+            }
+            None
+        }
+        ModuleImportSpec::Hiding(_, hidden_names) => {
+            for hidden_name in hidden_names.iter() {
+                let hidden = hidden_name.alias.as_ref().unwrap_or(&hidden_name.name);
+                if hidden == called_name {
+                    return None;
+                }
+            }
+            Some(called_name.to_vec())
+        }
+    }
+}
+
+impl HelperResolver for LSPServiceProvider {
+    fn resolve_helper_reference<'a>(
+        &mut self,
+        frontend: &CompileForm,
+        name: &[u8],
+    ) -> Option<HelperForm> {
+        for helper in frontend.helpers.iter() {
+            let nsref = match helper {
+                HelperForm::Defnsref(nsref) => nsref,
+                _ => continue,
+            };
+
+            let Some(imported_name) = resolve_imported_name(&nsref.specification, name) else {
+                continue;
+            };
+
+            let imported_filename = nsref
+                .longname
+                .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+            let imported_filename_decoded = decode_string(&imported_filename);
+
+            if let Ok((filename, file_body)) = get_file_content(
+                self.log.clone(),
+                self.fs.clone(),
+                self.get_workspace_root(),
+                &self.config.include_paths,
+                &decode_string(&imported_filename),
+            ) {
+                if let Some(file_uri) = self
+                    .get_workspace_root()
+                    .and_then(|r| r.join(&filename).to_str().map(urlify))
+                {
+                    self.save_doc(file_uri.clone(), file_body);
+                    self.ensure_parsed_document(&file_uri);
+
+                    if let Some(imported_doc) = self.get_parsed(&file_uri) {
+                        for imported_helper in imported_doc.compiled.helpers.iter() {
+                            match imported_helper {
+                                HelperForm::Defun(_, defun) if defun.name == imported_name => {
+                                    return Some(imported_helper.clone());
+                                }
+                                HelperForm::Defmacro(mac) if mac.name == imported_name => {
+                                    return Some(imported_helper.clone());
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Direct reference.
+        for f in frontend.helpers.iter() {
+            if matches!(f, HelperForm::Defun(_, _) | HelperForm::Defmacro(_)) {
+                if name == f.name() {
+                    return Some(f.clone());
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -8,10 +8,13 @@ use lsp_types::{SemanticToken, SemanticTokens, SemanticTokensParams};
 
 use crate::interfaces::ILogWriter;
 use crate::lsp::completion::PRIM_NAMES;
-use crate::lsp::parse::{add_bindings_to_set, add_sexp_bindings, recover_scopes, ParsedDoc, IncludedFileSpec};
+use crate::lsp::parse::{
+    add_bindings_to_set, add_sexp_bindings, recover_scopes, IncludedFileSpec, ParsedDoc,
+};
+use crate::lsp::resolve::HelperResolver;
 use crate::lsp::types::{
-    DocPosition, DocRange, Hash, IncludeData, IncludeKind, LSPServiceProvider, ParsedForm, ReparsedExp,
-    ReparsedHelper,
+    DocPosition, DocRange, Hash, IncludeData, IncludeKind, LSPServiceProvider, ParsedForm,
+    ReparsedExp, ReparsedHelper,
 };
 use crate::lsp::{
     TK_COMMENT_IDX, TK_DEFINITION_BIT, TK_FUNCTION_IDX, TK_KEYWORD_IDX, TK_MACRO_IDX,
@@ -21,7 +24,7 @@ use chialisp::compiler::clvm::sha256tree;
 use chialisp::compiler::comptypes::{
     BindingPattern, BodyForm, CompileForm, Export, HelperForm, LetFormKind, ModuleImportSpec,
 };
-use chialisp::compiler::sexp::SExp;
+use chialisp::compiler::sexp::{SExp, decode_string};
 use chialisp::compiler::srcloc::Srcloc;
 
 #[derive(Clone, Debug)]
@@ -91,55 +94,8 @@ fn collect_arg_tokens(
     }
 }
 
-fn find_call_token(
-    prims: &[Vec<u8>],
-    frontend: &CompileForm,
-    l: &Srcloc,
-    name: &Vec<u8>,
-) -> Option<(SemanticTokenSortable, Srcloc)> {
-    for f in frontend.helpers.iter() {
-        match f {
-            HelperForm::Defun(_inline, defun) => {
-                if &defun.name == name {
-                    let st = SemanticTokenSortable {
-                        loc: l.clone(),
-                        token_type: TK_FUNCTION_IDX,
-                        token_mod: 0,
-                    };
-                    return Some((st, defun.nl.clone()));
-                }
-            }
-            HelperForm::Defmacro(mac) => {
-                if &mac.name == name {
-                    let st = SemanticTokenSortable {
-                        loc: l.clone(),
-                        token_type: TK_MACRO_IDX,
-                        token_mod: 0,
-                    };
-                    return Some((st, mac.nl.clone()));
-                }
-            }
-            _ => {}
-        }
-    }
-
-    for p in prims.iter() {
-        if p == name {
-            return Some((
-                SemanticTokenSortable {
-                    loc: l.clone(),
-                    token_type: TK_FUNCTION_IDX,
-                    token_mod: 0,
-                },
-                l.clone(),
-            ));
-        }
-    }
-
-    None
-}
-
 pub struct DocumentProcessingDescription<'a> {
+    pub resolver: &'a mut dyn HelperResolver,
     pub prims: &'a [Vec<u8>],
     pub log: Rc<dyn ILogWriter>,
     pub id: RequestId,
@@ -148,7 +104,7 @@ pub struct DocumentProcessingDescription<'a> {
 }
 
 fn process_body_code(
-    env: &DocumentProcessingDescription,
+    env: &mut DocumentProcessingDescription,
     collected_tokens: &mut Vec<SemanticTokenSortable>,
     gotodef: &mut BTreeMap<SemanticTokenSortable, Srcloc>,
     argcollection: &HashMap<Vec<u8>, Srcloc>,
@@ -306,23 +262,56 @@ fn process_body_code(
 
             let head: &BodyForm = args[0].borrow();
             if let BodyForm::Value(SExp::Atom(l, a)) = head {
-                if let Some((call_token, location)) = find_call_token(env.prims, frontend, l, a) {
+                if let Some((call_token, location)) =
+                    match env.resolver.resolve_helper_reference(
+                        frontend,
+                        a
+                    ) {
+                        Some(HelperForm::Defun(_, d)) => {
+                            Some((SemanticTokenSortable {
+                                loc: l.clone(),
+                                token_type: TK_FUNCTION_IDX,
+                                token_mod: 0
+                            }, d.loc.clone()))
+                        }
+                        Some(HelperForm::Defmacro(m)) => {
+                            eprintln!("got macro {}", decode_string(&m.name));
+                            Some((SemanticTokenSortable {
+                                loc: l.clone(),
+                                token_type: TK_MACRO_IDX,
+                                token_mod: 0
+                            }, m.loc.clone()))
+                        }
+                        _ => None
+                    }
+                {
                     collected_tokens.push(call_token.clone());
                     gotodef.insert(call_token, location);
+                } else {
+                    for p in env.prims.iter() {
+                        if p == a {
+                            collected_tokens.push(SemanticTokenSortable {
+                                loc: l.clone(),
+                                token_type: TK_FUNCTION_IDX,
+                                token_mod: 0,
+                            });
+                        }
+                    }
+                }
+
+                for a in args.iter().skip(1) {
+                    process_body_code(
+                        env,
+                        collected_tokens,
+                        gotodef,
+                        argcollection,
+                        varcollection,
+                        frontend,
+                        a.clone(),
+                    );
                 }
             }
 
-            for a in args.iter().skip(1) {
-                process_body_code(
-                    env,
-                    collected_tokens,
-                    gotodef,
-                    argcollection,
-                    varcollection,
-                    frontend,
-                    a.clone(),
-                );
-            }
             // Handle the rest_args
             if let Some(tail) = rest_args {
                 process_body_code(
@@ -409,7 +398,7 @@ fn process_body_code(
 }
 
 pub fn build_semantic_tokens(
-    env: &DocumentProcessingDescription,
+    env: &mut DocumentProcessingDescription,
     comments: &HashMap<usize, usize>,
     goto_def: &mut BTreeMap<SemanticTokenSortable, Srcloc>,
     parsed: &ParsedDoc,
@@ -617,23 +606,28 @@ pub fn build_semantic_tokens(
                     &CompileForm {
                         loc: p.loc.clone(),
                         exp: p.expr.clone(),
-                        .. parsed.compiled.clone()
+                        ..parsed.compiled.clone()
                     },
                     p.expr.clone(),
                 );
             }
             Export::Function(f) => {
-                for (kind, loc) in
-                    [(TK_KEYWORD_IDX, f.kw_loc.as_ref()),
-                     (TK_KEYWORD_IDX, f.as_loc.as_ref()),
-                     (TK_VARIABLE_IDX, f.name.loc.as_ref()),
-                     (TK_VARIABLE_IDX, f.as_name.as_ref().and_then(|n| n.loc.as_ref()))
-                    ].iter().filter_map(|(k, l)| l.map(|l| (k,l)))
+                for (kind, loc) in [
+                    (TK_KEYWORD_IDX, f.kw_loc.as_ref()),
+                    (TK_KEYWORD_IDX, f.as_loc.as_ref()),
+                    (TK_VARIABLE_IDX, f.name.loc.as_ref()),
+                    (
+                        TK_VARIABLE_IDX,
+                        f.as_name.as_ref().and_then(|n| n.loc.as_ref()),
+                    ),
+                ]
+                .iter()
+                .filter_map(|(k, l)| l.map(|l| (k, l)))
                 {
                     collected_tokens.push(SemanticTokenSortable {
                         loc: loc.clone(),
                         token_type: *kind,
-                        token_mod: 0
+                        token_mod: 0,
                     })
                 }
             }
@@ -683,7 +677,7 @@ pub fn build_semantic_tokens(
 }
 
 fn do_semantic_tokens(
-    env: &DocumentProcessingDescription,
+    env: &mut DocumentProcessingDescription,
     comments: &HashMap<usize, usize>,
     goto_def: &mut BTreeMap<SemanticTokenSortable, Srcloc>,
     parsed: &ParsedDoc,
@@ -738,10 +732,12 @@ impl LSPSemtokRequestHandler for LSPServiceProvider {
         if let (Some(doc), Some(frontend)) = (self.get_doc(&uristring), self.get_parsed(&uristring))
         {
             let mut our_goto_defs = BTreeMap::new();
+            let log = self.log.clone();
             let resp = do_semantic_tokens(
-                &DocumentProcessingDescription {
+                &mut DocumentProcessingDescription {
+                    resolver: self,
                     prims: &PRIM_NAMES,
-                    log: self.log.clone(),
+                    log,
                     id,
                     uristring: &uristring,
                     lines: &doc.text,

--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -18,7 +18,9 @@ use crate::lsp::{
     TK_NUMBER_IDX, TK_PARAMETER_IDX, TK_READONLY_BIT, TK_STRING_IDX, TK_VARIABLE_IDX,
 };
 use chialisp::compiler::clvm::sha256tree;
-use chialisp::compiler::comptypes::{BodyForm, CompileForm, HelperForm, LetFormKind};
+use chialisp::compiler::comptypes::{
+    BindingPattern, BodyForm, CompileForm, HelperForm, LetFormKind,
+};
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
 
@@ -459,6 +461,8 @@ pub fn build_semantic_tokens(
 
     for form in parsed.compiled.helpers.iter() {
         match form {
+            HelperForm::Defnamespace(_) => {}
+            HelperForm::Defnsref(_) => {}
             HelperForm::Defconstant(defc) => {
                 if let Some(kw) = &defc.kw {
                     collected_tokens.push(SemanticTokenSortable {

--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -383,7 +383,7 @@ fn process_body_code(
                 ignored: false,
                 mod_kw: Some(l.clone()),
                 compiled: m.clone(),
-                exports: Vec::default(),
+                exports: HashMap::default(),
                 scopes,
                 helpers,
                 exp: Some(reparsed_exp),
@@ -595,34 +595,46 @@ pub fn build_semantic_tokens(
                 );
             }
         }
+    }
 
-        for export in parsed.exports.iter() {
-            match export {
-                Export::MainProgram(p) => {
-                    collect_arg_tokens(&mut collected_tokens, &mut argcollection, p.args.clone());
-                    if let Some(kw_loc) = p.kw_loc.as_ref() {
-                        collected_tokens.push(SemanticTokenSortable {
-                            loc: kw_loc.clone(),
-                            token_type: TK_KEYWORD_IDX,
-                            token_mod: 0,
-                        });
-                    }
-                    process_body_code(
-                        env,
-                        &mut collected_tokens,
-                        goto_def,
-                        &argcollection,
-                        &varcollection,
-                        &CompileForm {
-                            loc: p.loc.clone(),
-                            exp: p.expr.clone(),
-                            .. parsed.compiled.clone()
-                        },
-                        p.expr.clone(),
-                    );
+    for (_, export) in parsed.exports.iter() {
+        match export {
+            Export::MainProgram(p) => {
+                collect_arg_tokens(&mut collected_tokens, &mut argcollection, p.args.clone());
+                if let Some(kw_loc) = p.kw_loc.as_ref() {
+                    collected_tokens.push(SemanticTokenSortable {
+                        loc: kw_loc.clone(),
+                        token_type: TK_KEYWORD_IDX,
+                        token_mod: 0,
+                    });
                 }
-                Export::Function(f) => {
-                    todo!();
+                process_body_code(
+                    env,
+                    &mut collected_tokens,
+                    goto_def,
+                    &argcollection,
+                    &varcollection,
+                    &CompileForm {
+                        loc: p.loc.clone(),
+                        exp: p.expr.clone(),
+                        .. parsed.compiled.clone()
+                    },
+                    p.expr.clone(),
+                );
+            }
+            Export::Function(f) => {
+                for (kind, loc) in
+                    [(TK_KEYWORD_IDX, f.kw_loc.as_ref()),
+                     (TK_KEYWORD_IDX, f.as_loc.as_ref()),
+                     (TK_VARIABLE_IDX, f.name.loc.as_ref()),
+                     (TK_VARIABLE_IDX, f.as_name.as_ref().and_then(|n| n.loc.as_ref()))
+                    ].iter().filter_map(|(k, l)| l.map(|l| (k,l)))
+                {
+                    collected_tokens.push(SemanticTokenSortable {
+                        loc: loc.clone(),
+                        token_type: *kind,
+                        token_mod: 0
+                    })
                 }
             }
         }

--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -10,7 +10,7 @@ use crate::interfaces::ILogWriter;
 use crate::lsp::completion::PRIM_NAMES;
 use crate::lsp::parse::{add_bindings_to_set, add_sexp_bindings, recover_scopes, ParsedDoc};
 use crate::lsp::types::{
-    DocPosition, DocRange, Hash, IncludeData, IncludeKind, LSPServiceProvider, ReparsedExp,
+    DocPosition, DocRange, Hash, IncludeData, IncludeKind, LSPServiceProvider, ParsedForm, ReparsedExp,
     ReparsedHelper,
 };
 use crate::lsp::{
@@ -19,7 +19,7 @@ use crate::lsp::{
 };
 use chialisp::compiler::clvm::sha256tree;
 use chialisp::compiler::comptypes::{
-    BindingPattern, BodyForm, CompileForm, HelperForm, LetFormKind,
+    BindingPattern, BodyForm, CompileForm, Export, HelperForm, LetFormKind, ModuleImportSpec,
 };
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
@@ -346,7 +346,7 @@ fn process_body_code(
                     ReparsedHelper {
                         hash: Hash::new(&hash),
                         range: DocRange::from_srcloc(h.loc()),
-                        parsed: Ok(h.clone()),
+                        parsed: Ok(ParsedForm::Helper(h.clone())),
                     },
                 );
             }
@@ -383,6 +383,7 @@ fn process_body_code(
                 ignored: false,
                 mod_kw: Some(l.clone()),
                 compiled: m.clone(),
+                exports: Vec::default(),
                 scopes,
                 helpers,
                 exp: Some(reparsed_exp),
@@ -462,7 +463,52 @@ pub fn build_semantic_tokens(
     for form in parsed.compiled.helpers.iter() {
         match form {
             HelperForm::Defnamespace(_) => {}
-            HelperForm::Defnsref(_) => {}
+            HelperForm::Defnsref(nsref) => {
+                collected_tokens.push(SemanticTokenSortable {
+                    loc: nsref.kw.clone(),
+                    token_type: TK_KEYWORD_IDX,
+                    token_mod: 0,
+                });
+                collected_tokens.push(SemanticTokenSortable {
+                    loc: nsref.nl.clone(),
+                    token_type: TK_VARIABLE_IDX,
+                    token_mod: 0,
+                });
+                match &nsref.specification {
+                    ModuleImportSpec::Qualified(q) => {
+                        if let Some(target) = &q.target {
+                            collected_tokens.push(SemanticTokenSortable {
+                                loc: q.kw.clone(),
+                                token_type: TK_KEYWORD_IDX,
+                                token_mod: 0,
+                            });
+                            collected_tokens.push(SemanticTokenSortable {
+                                loc: q.nl.clone(),
+                                token_type: TK_VARIABLE_IDX,
+                                token_mod: 0,
+                            });
+                        }
+                    }
+                    ModuleImportSpec::Exposing(l, e) => {
+                        for h in e.iter() {
+                            collected_tokens.push(SemanticTokenSortable {
+                                loc: h.nl.clone(),
+                                token_type: TK_VARIABLE_IDX,
+                                token_mod: 0,
+                            });
+                        }
+                    }
+                    ModuleImportSpec::Hiding(l, e) => {
+                        for h in e.iter() {
+                            collected_tokens.push(SemanticTokenSortable {
+                                loc: h.nl.clone(),
+                                token_type: TK_VARIABLE_IDX,
+                                token_mod: 0,
+                            });
+                        }
+                    }
+                }
+            }
             HelperForm::Defconstant(defc) => {
                 if let Some(kw) = &defc.kw {
                     collected_tokens.push(SemanticTokenSortable {
@@ -540,6 +586,37 @@ pub fn build_semantic_tokens(
                     &parsed.compiled,
                     mac.program.exp.clone(),
                 );
+            }
+        }
+
+        for export in parsed.exports.iter() {
+            match export {
+                Export::MainProgram(p) => {
+                    collect_arg_tokens(&mut collected_tokens, &mut argcollection, p.args.clone());
+                    if let Some(kw_loc) = p.kw_loc.as_ref() {
+                        collected_tokens.push(SemanticTokenSortable {
+                            loc: kw_loc.clone(),
+                            token_type: TK_KEYWORD_IDX,
+                            token_mod: 0,
+                        });
+                    }
+                    process_body_code(
+                        env,
+                        &mut collected_tokens,
+                        goto_def,
+                        &argcollection,
+                        &varcollection,
+                        &CompileForm {
+                            loc: p.loc.clone(),
+                            exp: p.expr.clone(),
+                            .. parsed.compiled.clone()
+                        },
+                        p.expr.clone(),
+                    );
+                }
+                Export::Function(f) => {
+                    todo!();
+                }
             }
         }
     }

--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -8,7 +8,7 @@ use lsp_types::{SemanticToken, SemanticTokens, SemanticTokensParams};
 
 use crate::interfaces::ILogWriter;
 use crate::lsp::completion::PRIM_NAMES;
-use crate::lsp::parse::{add_bindings_to_set, add_sexp_bindings, recover_scopes, ParsedDoc};
+use crate::lsp::parse::{add_bindings_to_set, add_sexp_bindings, recover_scopes, ParsedDoc, IncludedFileSpec};
 use crate::lsp::types::{
     DocPosition, DocRange, Hash, IncludeData, IncludeKind, LSPServiceProvider, ParsedForm, ReparsedExp,
     ReparsedHelper,
@@ -367,14 +367,14 @@ fn process_body_code(
                 let hashed = Hash::new(&sha256tree(i.to_sexp()));
                 includes.insert(
                     hashed,
-                    IncludeData {
+                    IncludedFileSpec::Include(IncludeData {
                         loc: i.kw.clone(),
                         name_loc: i.nl.clone(),
                         kw_loc: i.kw.clone(),
                         kind: IncludeKind::Include,
                         filename: i.name.clone(),
                         found: None,
-                    },
+                    }),
                 );
             }
 
@@ -426,36 +426,43 @@ pub fn build_semantic_tokens(
     }
 
     for (_, incl) in parsed.includes.iter() {
-        collected_tokens.push(SemanticTokenSortable {
-            loc: incl.kw_loc.clone(),
-            token_type: TK_KEYWORD_IDX,
-            token_mod: 0,
-        });
-        collected_tokens.push(SemanticTokenSortable {
-            loc: incl.name_loc.clone(),
-            token_type: TK_STRING_IDX,
-            token_mod: 0,
-        });
-        match &incl.kind {
-            IncludeKind::Include => {}
-            IncludeKind::CompileFile(il) => {
+        match incl {
+            IncludedFileSpec::Include(incl) => {
                 collected_tokens.push(SemanticTokenSortable {
-                    loc: il.clone(),
-                    token_type: TK_VARIABLE_IDX,
-                    token_mod: TK_DEFINITION_BIT,
-                });
-            }
-            IncludeKind::EmbedFile(il, kl) => {
-                collected_tokens.push(SemanticTokenSortable {
-                    loc: il.clone(),
-                    token_type: TK_VARIABLE_IDX,
-                    token_mod: TK_DEFINITION_BIT,
-                });
-                collected_tokens.push(SemanticTokenSortable {
-                    loc: kl.clone(),
+                    loc: incl.kw_loc.clone(),
                     token_type: TK_KEYWORD_IDX,
                     token_mod: 0,
                 });
+                collected_tokens.push(SemanticTokenSortable {
+                    loc: incl.name_loc.clone(),
+                    token_type: TK_STRING_IDX,
+                    token_mod: 0,
+                });
+                match &incl.kind {
+                    IncludeKind::Include => {}
+                    IncludeKind::CompileFile(il) => {
+                        collected_tokens.push(SemanticTokenSortable {
+                            loc: il.clone(),
+                            token_type: TK_VARIABLE_IDX,
+                            token_mod: TK_DEFINITION_BIT,
+                        });
+                    }
+                    IncludeKind::EmbedFile(il, kl) => {
+                        collected_tokens.push(SemanticTokenSortable {
+                            loc: il.clone(),
+                            token_type: TK_VARIABLE_IDX,
+                            token_mod: TK_DEFINITION_BIT,
+                        });
+                        collected_tokens.push(SemanticTokenSortable {
+                            loc: kl.clone(),
+                            token_type: TK_KEYWORD_IDX,
+                            token_mod: 0,
+                        });
+                    }
+                }
+            }
+            IncludedFileSpec::Import(imp) => {
+                // Handled in the helper personality.
             }
         }
     }

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -979,6 +979,30 @@ impl LSPServiceProvider {
             .map(|d| stringify_doc(&d.text))
             .unwrap_or_else(|| Err(format!("don't have file {}", filename)))
     }
+
+    pub fn get_file_uri_and_ensure_parsing(
+        &mut self,
+        filename: &str
+    ) -> Option<(String, ParsedDoc)> {
+        if let Ok((filename, file_body)) = get_file_content(
+            self.log.clone(),
+            self.fs.clone(),
+            self.get_workspace_root(),
+            &self.config.include_paths,
+            &filename,
+        ) {
+            if let Some(file_uri) = self
+                .get_workspace_root()
+                .and_then(|r| r.join(&filename).to_str().map(urlify))
+            {
+                self.save_doc(file_uri.clone(), file_body);
+                self.ensure_parsed_document(&file_uri);
+                return self.get_parsed(&file_uri).map(|parsed| (file_uri, parsed));
+            }
+        }
+
+        None
+    }
 }
 
 // Note: This is using a directive that ensures that this code is only included

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -721,9 +721,9 @@ impl LSPServiceProvider {
     }
 
     pub fn save_doc(&mut self, uristring: String, dd: DocData) {
-        let cell: &RefCell<HashMap<String, DocData>> = self.document_collection.borrow();
         self.parsed_documents.remove(&uristring);
         self.clear_missing_import_files_for_doc(&uristring);
+        let cell: &RefCell<HashMap<String, DocData>> = self.document_collection.borrow();
         cell.replace_with(|coll| {
             let mut repl = HashMap::new();
             swap(&mut repl, coll);

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -25,12 +25,14 @@ use url::{Host, Url};
 
 use crate::interfaces::{IFileReader, ILogWriter};
 use crate::lsp::compopts::{get_file_content, LSPCompilerOpts};
-use crate::lsp::parse::{make_simple_ranges, ParsedDoc, IncludedFileSpec};
+use crate::lsp::parse::{make_simple_ranges, IncludedFileSpec, ParsedDoc};
 use crate::lsp::patch::stringify_doc;
 use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset, ReparsedModule};
 use crate::lsp::semtok::SemanticTokenSortable;
 use chialisp::compiler::compiler::DefaultCompilerOpts;
-use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompilerOpts, Export, HelperForm, LongNameTranslation};
+use chialisp::compiler::comptypes::{
+    BodyForm, CompileErr, CompilerOpts, Export, HelperForm, LongNameTranslation,
+};
 use chialisp::compiler::frontend::HelperFormResult;
 use chialisp::compiler::prims::prims;
 use chialisp::compiler::sexp::{decode_string, SExp};
@@ -658,18 +660,16 @@ impl LSPServiceProvider {
         let errors = missing_includes
             .iter()
             .map(|i| {
-                let loc =
-                    match i {
-                        IncludedFileSpec::Include(i) => i.name_loc.clone(),
-                        IncludedFileSpec::Import(imp) => imp.loc.clone()
-                    };
-                let filename =
-                    match i {
-                        IncludedFileSpec::Include(i) => i.filename.clone(),
-                        IncludedFileSpec::Import(imp) => {
-                            imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()))
-                        }
-                    };
+                let loc = match i {
+                    IncludedFileSpec::Include(i) => i.name_loc.clone(),
+                    IncludedFileSpec::Import(imp) => imp.loc.clone(),
+                };
+                let filename = match i {
+                    IncludedFileSpec::Include(i) => i.filename.clone(),
+                    IncludedFileSpec::Import(imp) => imp
+                        .longname
+                        .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string())),
+                };
                 Diagnostic {
                     range: DocRange::from_srcloc(loc).to_range(),
                     severity: None,
@@ -732,7 +732,12 @@ impl LSPServiceProvider {
         self.parsed_documents.insert(uristring, p);
     }
 
-    pub fn try_handle_incoming_file(&mut self, new_helpers: &mut ReparsedModule, target_filename: &[u8], contained: bool) -> bool {
+    pub fn try_handle_incoming_file(
+        &mut self,
+        new_helpers: &mut ReparsedModule,
+        target_filename: &[u8],
+        contained: bool,
+    ) -> bool {
         let mut success = false;
 
         if let Ok((filename, file_body)) = get_file_content(
@@ -809,7 +814,9 @@ impl LSPServiceProvider {
                         self.try_handle_incoming_file(&mut new_helpers, &incfile.filename, true);
                     }
                     IncludedFileSpec::Import(imp) => {
-                        let filename_inc = imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+                        let filename_inc = imp
+                            .longname
+                            .as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
                         if !self.try_handle_incoming_file(&mut new_helpers, &filename_inc, false) {
                             /* XXX implement me.
                             let filename_clsp = imp.longname.as_u8_vec(LongNameTranslaction::Filename(".clsp".to_string()));

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -25,12 +25,12 @@ use url::{Host, Url};
 
 use crate::interfaces::{IFileReader, ILogWriter};
 use crate::lsp::compopts::{get_file_content, LSPCompilerOpts};
-use crate::lsp::parse::{make_simple_ranges, ParsedDoc};
+use crate::lsp::parse::{make_simple_ranges, ParsedDoc, IncludedFileSpec};
 use crate::lsp::patch::stringify_doc;
-use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset};
+use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset, ReparsedModule};
 use crate::lsp::semtok::SemanticTokenSortable;
 use chialisp::compiler::compiler::DefaultCompilerOpts;
-use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompilerOpts, Export, HelperForm};
+use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompilerOpts, Export, HelperForm, LongNameTranslation};
 use chialisp::compiler::frontend::HelperFormResult;
 use chialisp::compiler::prims::prims;
 use chialisp::compiler::sexp::{decode_string, SExp};
@@ -657,19 +657,33 @@ impl LSPServiceProvider {
         let missing_includes = self.check_for_missing_include_files(uristring);
         let errors = missing_includes
             .iter()
-            .map(|i| Diagnostic {
-                range: DocRange::from_srcloc(i.name_loc.clone()).to_range(),
-                severity: None,
-                code: None,
-                code_description: None,
-                source: Some("chialisp".to_string()),
-                message: format!(
-                    "missing include file {} or path not set",
-                    decode_string(&i.filename)
-                ),
-                tags: None,
-                related_information: None,
-                data: None,
+            .map(|i| {
+                let loc =
+                    match i {
+                        IncludedFileSpec::Include(i) => i.name_loc.clone(),
+                        IncludedFileSpec::Import(imp) => imp.loc.clone()
+                    };
+                let filename =
+                    match i {
+                        IncludedFileSpec::Include(i) => i.filename.clone(),
+                        IncludedFileSpec::Import(imp) => {
+                            imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()))
+                        }
+                    };
+                Diagnostic {
+                    range: DocRange::from_srcloc(loc).to_range(),
+                    severity: None,
+                    code: None,
+                    code_description: None,
+                    source: Some("chialisp".to_string()),
+                    message: format!(
+                        "missing include file {} or path not set",
+                        decode_string(&filename)
+                    ),
+                    tags: None,
+                    related_information: None,
+                    data: None,
+                }
             })
             .collect();
 
@@ -718,6 +732,39 @@ impl LSPServiceProvider {
         self.parsed_documents.insert(uristring, p);
     }
 
+    pub fn try_handle_incoming_file(&mut self, new_helpers: &mut ReparsedModule, target_filename: &[u8], contained: bool) -> bool {
+        let mut success = false;
+
+        if let Ok((filename, file_body)) = get_file_content(
+            self.log.clone(),
+            self.fs.clone(),
+            self.get_workspace_root(),
+            &self.config.include_paths,
+            &decode_string(&target_filename),
+        ) {
+            if let Some(file_uri) = self
+                .get_workspace_root()
+                .and_then(|r| r.join(&filename).to_str().map(urlify))
+            {
+                // Keep the contents.
+                self.save_doc(file_uri.clone(), file_body);
+                // Do parsing on this document if the content changed
+                // or it's new.
+                self.ensure_parsed_document(&file_uri);
+                // If it parsed, we have the helpers and can populate
+                // autocomplete/error functionality.
+                if let Some(p) = self.get_parsed(&file_uri) {
+                    for (hash, helper) in p.helpers.iter() {
+                        new_helpers.helpers.insert(hash.clone(), helper.clone());
+                        success = true;
+                    }
+                }
+            }
+        }
+
+        success
+    }
+
     pub fn ensure_parsed_document(&mut self, uristring: &str) {
         let def_opts = Rc::new(DefaultCompilerOpts::new(uristring));
         let opts = Rc::new(LSPCompilerOpts::new(
@@ -750,35 +797,26 @@ impl LSPServiceProvider {
                 &output.helpers,
             );
 
-            for (_, incfile) in new_helpers.includes.iter() {
-                if incfile.kind != IncludeKind::Include
-                    || incfile.filename.starts_with(b"*")
-                {
-                    continue;
-                }
+            for (_, incfile) in new_helpers.includes.clone().iter() {
+                match incfile {
+                    IncludedFileSpec::Include(incfile) => {
+                        if incfile.kind != IncludeKind::Include
+                            || incfile.filename.starts_with(b"*")
+                        {
+                            continue;
+                        }
 
-                if let Ok((filename, file_body)) = get_file_content(
-                    self.log.clone(),
-                    self.fs.clone(),
-                    self.get_workspace_root(),
-                    &self.config.include_paths,
-                    &decode_string(&incfile.filename),
-                ) {
-                    if let Some(file_uri) = self
-                        .get_workspace_root()
-                        .and_then(|r| r.join(filename).to_str().map(urlify))
-                    {
-                        // Keep the contents.
-                        self.save_doc(file_uri.clone(), file_body);
-                        // Do parsing on this document if the content changed
-                        // or it's new.
-                        self.ensure_parsed_document(&file_uri);
-                        // If it parsed, we have the helpers and can populate
-                        // autocomplete/error functionality.
-                        if let Some(p) = self.get_parsed(&file_uri) {
-                            for (hash, helper) in p.helpers.iter() {
-                                new_helpers.helpers.insert(hash.clone(), helper.clone());
-                            }
+                        self.try_handle_incoming_file(&mut new_helpers, &incfile.filename, true);
+                    }
+                    IncludedFileSpec::Import(imp) => {
+                        let filename_inc = imp.longname.as_u8_vec(LongNameTranslation::Filename(".clinc".to_string()));
+                        if !self.try_handle_incoming_file(&mut new_helpers, &filename_inc, false) {
+                            /* XXX implement me.
+                            let filename_clsp = imp.longname.as_u8_vec(LongNameTranslaction::Filename(".clsp".to_string()));
+                            // When read, the exports (or default export) match .program and
+                            // other imports.
+                            self.try_handle_incoming_file(&filename_clsp, false);
+                            */
                         }
                     }
                 }

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -737,13 +737,14 @@ impl LSPServiceProvider {
                 .get(uristring)
                 .cloned()
                 .unwrap_or_else(|| ParsedDoc::new(startloc));
-            let ranges = make_simple_ranges(&doc.text);
+            let (module_style, ranges) = make_simple_ranges(&doc.text);
             eprintln!("got ranges {ranges:?}");
             let mut new_helpers = reparse_subset(
                 &self.prims,
                 opts,
                 &doc.text,
                 uristring,
+                module_style,
                 &ranges,
                 &output.compiled,
                 &output.helpers,

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -30,7 +30,8 @@ use crate::lsp::patch::stringify_doc;
 use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset};
 use crate::lsp::semtok::SemanticTokenSortable;
 use chialisp::compiler::compiler::DefaultCompilerOpts;
-use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompilerOpts, HelperForm};
+use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompilerOpts, Export, HelperForm};
+use chialisp::compiler::frontend::HelperFormResult;
 use chialisp::compiler::prims::prims;
 use chialisp::compiler::sexp::{decode_string, SExp};
 use chialisp::compiler::srcloc::Srcloc;
@@ -737,6 +738,7 @@ impl LSPServiceProvider {
                 .cloned()
                 .unwrap_or_else(|| ParsedDoc::new(startloc));
             let ranges = make_simple_ranges(&doc.text);
+            eprintln!("got ranges {ranges:?}");
             let mut new_helpers = reparse_subset(
                 &self.prims,
                 opts,
@@ -749,8 +751,7 @@ impl LSPServiceProvider {
 
             for (_, incfile) in new_helpers.includes.iter() {
                 if incfile.kind != IncludeKind::Include
-                    || incfile.filename == b"*standard-cl-21*"
-                    || incfile.filename == b"*standard-cl-22*"
+                    || incfile.filename.starts_with(b"*")
                 {
                     continue;
                 }
@@ -1125,11 +1126,17 @@ pub struct IncludeData {
 }
 
 #[derive(Debug, Clone)]
+pub enum ParsedForm<H> {
+    ModuleExport(Export),
+    Helper(H),
+}
+
+#[derive(Debug, Clone)]
 // A helper (defmacro, defun, etc)  that we parsed alone via document range.
 pub struct ReparsedHelper {
     pub hash: Hash,
     pub range: DocRange,
-    pub parsed: Result<HelperForm, CompileErr>,
+    pub parsed: Result<ParsedForm<HelperForm>, CompileErr>,
 }
 
 #[derive(Debug, Clone)]

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -560,6 +560,9 @@ pub struct LSPServiceProvider {
 
     // These aren't shared.
     pub parsed_documents: HashMap<String, ParsedDoc>,
+    // Set of import targets we attempted and could not locate, keyed by
+    // (document uri, imported filename).
+    pub missing_import_files: HashSet<(String, Vec<u8>)>,
     pub goto_defs: HashMap<String, BTreeMap<SemanticTokenSortable, Srcloc>>,
 
     // Collection of all known errors we're throwing.
@@ -720,6 +723,7 @@ impl LSPServiceProvider {
     pub fn save_doc(&mut self, uristring: String, dd: DocData) {
         let cell: &RefCell<HashMap<String, DocData>> = self.document_collection.borrow();
         self.parsed_documents.remove(&uristring);
+        self.clear_missing_import_files_for_doc(&uristring);
         cell.replace_with(|coll| {
             let mut repl = HashMap::new();
             swap(&mut repl, coll);
@@ -729,7 +733,13 @@ impl LSPServiceProvider {
     }
 
     fn save_parse(&mut self, uristring: String, p: ParsedDoc) {
+        self.clear_missing_import_files_for_doc(&uristring);
         self.parsed_documents.insert(uristring, p);
+    }
+
+    pub fn clear_missing_import_files_for_doc(&mut self, uristring: &str) {
+        self.missing_import_files
+            .retain(|(parsed_file, _)| parsed_file != uristring);
     }
 
     pub fn try_handle_incoming_file(
@@ -908,6 +918,7 @@ impl LSPServiceProvider {
             document_collection: Rc::new(RefCell::new(HashMap::new())),
 
             parsed_documents: HashMap::new(),
+            missing_import_files: HashSet::new(),
             goto_defs: HashMap::new(),
             thrown_errors: HashMap::new(),
 

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -2222,3 +2222,79 @@ fn test_sem_tok_for_module_just_export() {
         ]
     );
 }
+
+#[test]
+fn test_sem_tok_for_module_qualified_import() {
+    let mut lsp = LSPServiceProvider::new(
+        Rc::new(FSFileReader::new()),
+        Rc::new(EPrintWriter::new()),
+        true,
+    );
+    lsp.set_workspace_root(PathBuf::from(r"."));
+    lsp.set_config(ConfigJson {
+        include_paths: vec!["../resources/tests".to_string()],
+    });
+    let file = "file://./test.cl".to_string();
+    let open_msg = make_did_open_message(
+        &file,
+        1,
+        indoc! {"
+        (import qualified std.reverse)
+        (export (X) (std.reverse.reverse X))"}
+        .to_string(),
+    );
+    let sem_tok = make_get_semantic_tokens_msg(&file, 2);
+    lsp.handle_message(&open_msg)
+        .expect("should be ok to take open msg");
+    let r2 = lsp
+        .handle_message(&sem_tok)
+        .expect("should be ok to send sem tok");
+    let decoded_tokens: SemanticTokens = serde_json::from_str(&get_msg_params(&r2[0])).unwrap();
+    assert_eq!(
+        decoded_tokens.data,
+        vec![
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 17,
+                length: 11,
+                token_type: TK_VARIABLE_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 1,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 8,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 1,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 4,
+                length: 19,
+                token_type: TK_FUNCTION_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 20,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 0,
+            }
+        ]
+    );
+}

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -1971,7 +1971,6 @@ fn test_sem_tok_for_module_style() {
     let r2 = lsp
         .handle_message(&sem_tok)
         .expect("should be ok to send sem tok");
-    eprintln!("msg {}", get_msg_params(&r2[0]));
     let decoded_tokens: SemanticTokens = serde_json::from_str(&get_msg_params(&r2[0])).unwrap();
     assert_eq!(
         decoded_tokens.data,
@@ -2042,6 +2041,97 @@ fn test_sem_tok_for_module_style() {
             SemanticToken {
                 delta_line: 0,
                 delta_start: 2,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 0,
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_sem_tok_for_module_style_reverse_function() {
+    let mut lsp = LSPServiceProvider::new(
+        Rc::new(FSFileReader::new()),
+        Rc::new(EPrintWriter::new()),
+        true,
+    );
+    lsp.set_workspace_root(PathBuf::from(r"."));
+    lsp.set_config(ConfigJson {
+        include_paths: vec!["../resources/tests".to_string()],
+    });
+    let file = "file://./test.cl".to_string();
+    let open_msg = make_did_open_message(
+        &file,
+        1,
+        indoc! {"
+(import std.reverse exposing (reverse as rev))
+(include *standard-cl-25*)
+(export (X) (rev X))"}
+        .to_string(),
+    );
+    let sem_tok = make_get_semantic_tokens_msg(&file, 2);
+    lsp.handle_message(&open_msg)
+        .expect("should be ok to take open msg");
+    let r2 = lsp
+        .handle_message(&sem_tok)
+        .expect("should be ok to send sem tok");
+    let decoded_tokens: SemanticTokens = serde_json::from_str(&get_msg_params(&r2[0])).unwrap();
+    assert_eq!(
+        decoded_tokens.data,
+        vec![
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 7,
+                length: 10,
+                token_type: TK_VARIABLE_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 1,
+                delta_start: 1,
+                length: 7,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 8,
+                length: 16,
+                token_type: TK_STRING_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 1,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 8,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 1,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 4,
+                length: 3,
+                token_type: TK_FUNCTION_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 4,
                 length: 1,
                 token_type: TK_PARAMETER_IDX,
                 token_modifiers_bitset: 0,

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -15,9 +15,10 @@ use crate::lsp::{
 use lsp_server::{Message, Notification, Request, RequestId};
 use lsp_types::{
     CompletionItem, CompletionParams, CompletionResponse, DidChangeTextDocumentParams,
-    DidOpenTextDocumentParams, PartialResultParams, Position, Range, SemanticToken, SemanticTokens,
-    SemanticTokensParams, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Url, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
+    DidOpenTextDocumentParams, PartialResultParams, Position, PublishDiagnosticsParams, Range,
+    SemanticToken, SemanticTokens, SemanticTokensParams, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Url,
+    VersionedTextDocumentIdentifier, WorkDoneProgressParams,
 };
 
 use crate::dbg::source::parse_srcloc;
@@ -2055,6 +2056,51 @@ fn test_sem_tok_for_module_style() {
             },
         ]
     );
+}
+
+#[test]
+fn test_missing_import_reports_diagnostic() {
+    let mut lsp = LSPServiceProvider::new(
+        Rc::new(FSFileReader::new()),
+        Rc::new(EPrintWriter::new()),
+        true,
+    );
+    lsp.set_workspace_root(PathBuf::from(r"."));
+    lsp.set_config(ConfigJson {
+        include_paths: vec!["../resources/tests".to_string()],
+    });
+    let file = "file://./test.cl".to_string();
+    let open_msg = make_did_open_message(
+        &file,
+        1,
+        indoc! {"
+(import std.missing)
+(export (X) X)"}
+        .to_string(),
+    );
+    let sem_tok = make_get_semantic_tokens_msg(&file, 2);
+    let out_msgs = run_lsp(&mut lsp, &vec![open_msg, sem_tok]).expect("should run");
+
+    let diag_sets: Vec<PublishDiagnosticsParams> = out_msgs
+        .iter()
+        .filter_map(|msg| {
+            if let Message::Notification(Notification { method, params }) = msg {
+                if method == "textDocument/publishDiagnostics" {
+                    return serde_json::from_value(params.clone()).ok();
+                }
+            }
+            None
+        })
+        .collect();
+    assert!(!diag_sets.is_empty());
+
+    let missing_messages: Vec<String> = diag_sets
+        .iter()
+        .flat_map(|set| set.diagnostics.iter())
+        .map(|d| d.message.clone())
+        .filter(|m| m.contains("std/missing.clinc"))
+        .collect();
+    assert_eq!(missing_messages.len(), 1);
 }
 
 #[test]

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 
 use crate::lsp::{
     LSPServiceMessageHandler, LSPServiceProvider, TK_COMMENT_IDX, TK_DEFINITION_BIT,
-    TK_FUNCTION_IDX, TK_KEYWORD_IDX, TK_NUMBER_IDX, TK_PARAMETER_IDX, TK_STRING_IDX,
-    TK_VARIABLE_IDX, TK_MACRO_IDX,
+    TK_FUNCTION_IDX, TK_KEYWORD_IDX, TK_MACRO_IDX, TK_NUMBER_IDX, TK_PARAMETER_IDX, TK_STRING_IDX,
+    TK_VARIABLE_IDX,
 };
 
 use lsp_server::{Message, Notification, Request, RequestId};
@@ -22,7 +22,7 @@ use lsp_types::{
 
 use crate::dbg::source::parse_srcloc;
 use crate::interfaces::{EPrintWriter, FSFileReader};
-use crate::lsp::parse::{is_first_in_list, make_simple_ranges, ParsedDoc, IncludedFileSpec};
+use crate::lsp::parse::{is_first_in_list, make_simple_ranges, IncludedFileSpec, ParsedDoc};
 use crate::lsp::patch::{split_text, stringify_doc, PatchableDocument};
 use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset};
 use crate::lsp::types::{ConfigJson, DocData, DocPosition, DocRange, IncludeData};
@@ -559,38 +559,41 @@ fn test_simple_ranges() {
     let simple_ranges = make_simple_ranges(&split_text(&content));
     assert_eq!(
         simple_ranges,
-        (false, vec![
-            DocRange {
-                start: DocPosition {
-                    line: 0,
-                    character: 5
+        (
+            false,
+            vec![
+                DocRange {
+                    start: DocPosition {
+                        line: 0,
+                        character: 5
+                    },
+                    end: DocPosition {
+                        line: 0,
+                        character: 7
+                    }
                 },
-                end: DocPosition {
-                    line: 0,
-                    character: 7
-                }
-            },
-            DocRange {
-                start: DocPosition {
-                    line: 1,
-                    character: 2,
+                DocRange {
+                    start: DocPosition {
+                        line: 1,
+                        character: 2,
+                    },
+                    end: DocPosition {
+                        line: 3,
+                        character: 5
+                    }
                 },
-                end: DocPosition {
-                    line: 3,
-                    character: 5
+                DocRange {
+                    start: DocPosition {
+                        line: 4,
+                        character: 2
+                    },
+                    end: DocPosition {
+                        line: 4,
+                        character: 7
+                    }
                 }
-            },
-            DocRange {
-                start: DocPosition {
-                    line: 4,
-                    character: 2
-                },
-                end: DocPosition {
-                    line: 4,
-                    character: 7
-                }
-            }
-        ])
+            ]
+        )
     );
 }
 
@@ -859,12 +862,17 @@ fn include_is_annotated() {
   )"}
         .to_string()],
     );
-    let includes_flat: Vec<IncludeData> =
-        combined.includes.iter().filter_map(|(_, v)| if let IncludedFileSpec::Include(i) = v {
-            Some(i.clone())
-        } else {
-            None
-        }).collect();
+    let includes_flat: Vec<IncludeData> = combined
+        .includes
+        .iter()
+        .filter_map(|(_, v)| {
+            if let IncludedFileSpec::Include(i) = v {
+                Some(i.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
     assert_eq!(includes_flat[0].kw_loc.line, 2);
     assert_eq!(includes_flat[0].kw_loc.col, 4);
     assert_eq!(includes_flat[0].name_loc.line, 2);
@@ -2163,7 +2171,7 @@ fn test_sem_tok_for_module_just_export() {
         &file,
         1,
         indoc! {"
-(export (X) (+ X 1))"}
+        (export (X) (+ X 1))"}
         .to_string(),
     );
     let sem_tok = make_get_semantic_tokens_msg(&file, 2);

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -2090,7 +2090,14 @@ fn test_sem_tok_for_module_style_reverse_function() {
             SemanticToken {
                 delta_line: 0,
                 delta_start: 7,
-                length: 10,
+                length: 11,
+                token_type: TK_VARIABLE_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 22,
+                length: 7,
                 token_type: TK_VARIABLE_IDX,
                 token_modifiers_bitset: 0,
             },
@@ -2136,6 +2143,74 @@ fn test_sem_tok_for_module_style_reverse_function() {
                 token_type: TK_PARAMETER_IDX,
                 token_modifiers_bitset: 0,
             },
+        ]
+    );
+}
+
+#[test]
+fn test_sem_tok_for_module_just_export() {
+    let mut lsp = LSPServiceProvider::new(
+        Rc::new(FSFileReader::new()),
+        Rc::new(EPrintWriter::new()),
+        true,
+    );
+    lsp.set_workspace_root(PathBuf::from(r"."));
+    lsp.set_config(ConfigJson {
+        include_paths: vec!["../resources/tests".to_string()],
+    });
+    let file = "file://./test.cl".to_string();
+    let open_msg = make_did_open_message(
+        &file,
+        1,
+        indoc! {"
+(export (X) (+ X 1))"}
+        .to_string(),
+    );
+    let sem_tok = make_get_semantic_tokens_msg(&file, 2);
+    lsp.handle_message(&open_msg)
+        .expect("should be ok to take open msg");
+    let r2 = lsp
+        .handle_message(&sem_tok)
+        .expect("should be ok to send sem tok");
+    let decoded_tokens: SemanticTokens = serde_json::from_str(&get_msg_params(&r2[0])).unwrap();
+    assert_eq!(
+        decoded_tokens.data,
+        vec![
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 8,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 1,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 4,
+                length: 1,
+                token_type: TK_FUNCTION_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 2,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 2,
+                length: 1,
+                token_type: TK_NUMBER_IDX,
+                token_modifiers_bitset: 0,
+            }
         ]
     );
 }

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -1938,3 +1938,53 @@ fn test_first_line_comment() {
         ]
     );
 }
+
+#[test]
+fn test_sem_tok_for_module_style() {
+    let mut lsp = LSPServiceProvider::new(
+        Rc::new(FSFileReader::new()),
+        Rc::new(EPrintWriter::new()),
+        true,
+    );
+    lsp.set_workspace_root(PathBuf::from(r"."));
+    lsp.set_config(ConfigJson {
+        include_paths: vec!["./resources/tests".to_string()],
+    });
+    let file = "file://./test.cl".to_string();
+    let open_msg = make_did_open_message(
+        &file,
+        1,
+        indoc! {"
+(import std.assert)
+
+(export F (X Y) (assert X Y))"}
+        .to_string(),
+    );
+    let sem_tok = make_get_semantic_tokens_msg(&file, 2);
+    lsp.handle_message(&open_msg)
+        .expect("should be ok to take open msg");
+    let r2 = lsp
+        .handle_message(&sem_tok)
+        .expect("should be ok to send sem tok");
+    eprintln!("msg {}", get_msg_params(&r2[0]));
+    let decoded_tokens: SemanticTokens = serde_json::from_str(&get_msg_params(&r2[0])).unwrap();
+    assert_eq!(
+        decoded_tokens.data,
+        vec![
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 0,
+                length: 16,
+                token_type: TK_COMMENT_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 1,
+                delta_start: 1,
+                length: 3,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+        ]
+    );
+}

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -1956,8 +1956,8 @@ fn test_sem_tok_for_module_style() {
         1,
         indoc! {"
 (import std.assert)
-
-(export F (X Y) (assert X Y))"}
+(include *standard-cl-25*)
+(export (X Y) (assert X Y))"}
         .to_string(),
     );
     let sem_tok = make_get_semantic_tokens_msg(&file, 2);
@@ -1973,16 +1973,65 @@ fn test_sem_tok_for_module_style() {
         vec![
             SemanticToken {
                 delta_line: 0,
-                delta_start: 0,
-                length: 16,
-                token_type: TK_COMMENT_IDX,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 7,
+                length: 10,
+                token_type: TK_VARIABLE_IDX,
                 token_modifiers_bitset: 0,
             },
             SemanticToken {
                 delta_line: 1,
                 delta_start: 1,
-                length: 3,
+                length: 7,
                 token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 8,
+                length: 16,
+                token_type: TK_STRING_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 1,
+                delta_start: 1,
+                length: 6,
+                token_type: TK_KEYWORD_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 8,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 1,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 2,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 1,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 11,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 2,
+                length: 1,
+                token_type: TK_PARAMETER_IDX,
                 token_modifiers_bitset: 0,
             },
         ]

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use crate::lsp::{
     LSPServiceMessageHandler, LSPServiceProvider, TK_COMMENT_IDX, TK_DEFINITION_BIT,
     TK_FUNCTION_IDX, TK_KEYWORD_IDX, TK_NUMBER_IDX, TK_PARAMETER_IDX, TK_STRING_IDX,
-    TK_VARIABLE_IDX,
+    TK_VARIABLE_IDX, TK_MACRO_IDX,
 };
 
 use lsp_server::{Message, Notification, Request, RequestId};
@@ -22,7 +22,7 @@ use lsp_types::{
 
 use crate::dbg::source::parse_srcloc;
 use crate::interfaces::{EPrintWriter, FSFileReader};
-use crate::lsp::parse::{is_first_in_list, make_simple_ranges, ParsedDoc};
+use crate::lsp::parse::{is_first_in_list, make_simple_ranges, ParsedDoc, IncludedFileSpec};
 use crate::lsp::patch::{split_text, stringify_doc, PatchableDocument};
 use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset};
 use crate::lsp::types::{ConfigJson, DocData, DocPosition, DocRange, IncludeData};
@@ -860,7 +860,11 @@ fn include_is_annotated() {
         .to_string()],
     );
     let includes_flat: Vec<IncludeData> =
-        combined.includes.iter().map(|(_, v)| v.clone()).collect();
+        combined.includes.iter().filter_map(|(_, v)| if let IncludedFileSpec::Include(i) = v {
+            Some(i.clone())
+        } else {
+            None
+        }).collect();
     assert_eq!(includes_flat[0].kw_loc.line, 2);
     assert_eq!(includes_flat[0].kw_loc.col, 4);
     assert_eq!(includes_flat[0].name_loc.line, 2);
@@ -1949,7 +1953,7 @@ fn test_sem_tok_for_module_style() {
     );
     lsp.set_workspace_root(PathBuf::from(r"."));
     lsp.set_config(ConfigJson {
-        include_paths: vec!["./resources/tests".to_string()],
+        include_paths: vec!["../resources/tests".to_string()],
     });
     let file = "file://./test.cl".to_string();
     let open_msg = make_did_open_message(
@@ -2023,7 +2027,14 @@ fn test_sem_tok_for_module_style() {
             },
             SemanticToken {
                 delta_line: 0,
-                delta_start: 11,
+                delta_start: 4,
+                length: 6,
+                token_type: TK_MACRO_IDX,
+                token_modifiers_bitset: 0,
+            },
+            SemanticToken {
+                delta_line: 0,
+                delta_start: 7,
                 length: 1,
                 token_type: TK_PARAMETER_IDX,
                 token_modifiers_bitset: 0,

--- a/wasm/src/tests/mod.rs
+++ b/wasm/src/tests/mod.rs
@@ -559,7 +559,7 @@ fn test_simple_ranges() {
     let simple_ranges = make_simple_ranges(&split_text(&content));
     assert_eq!(
         simple_ranges,
-        vec![
+        (false, vec![
             DocRange {
                 start: DocPosition {
                     line: 0,
@@ -590,7 +590,7 @@ fn test_simple_ranges() {
                     character: 7
                 }
             }
-        ]
+        ])
     );
 }
 
@@ -705,12 +705,13 @@ fn run_reparse_steps(
 
     for content in text_inputs.iter() {
         let text = split_text(&content);
-        let ranges = make_simple_ranges(&text);
+        let (module_style, ranges) = make_simple_ranges(&text);
         let reparsed = reparse_subset(
             &prims,
             opts.clone(),
             &text,
             &file,
+            module_style,
             &ranges,
             &doc.compiled,
             &HashMap::new(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add LSP state for unresolved import targets via `missing_import_files: HashSet<(String, Vec<u8>)>`
- extend `update_include_state` so it updates both include `found` flags and unresolved import tracking
- fix `check_for_missing_include_files` import handling to always resolve imports, call `update_include_state` for both success/failure, and return missing imports for diagnostics
- clear unresolved-import state when document parse/input is refreshed and when full parse state is reset on config file changes
- add a regression test proving an unresolved `(import std.missing)` produces a missing-include diagnostic
- fix a Rust borrow-checker error in `save_doc` by reordering cleanup operations before borrowing `document_collection`

## Testing
- added regression test: `test_missing_import_reports_diagnostic` in `wasm/src/tests/mod.rs`
- CI failure root cause analyzed via `gh run view --log-failed` (borrow conflict in `save_doc`), then fixed
- local test execution still blocked in this environment by Cargo/toolchain incompatibility with `edition2024` crates (same limitation as previously noted)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-210c66a8-00c8-45bc-8731-66add87e5785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-210c66a8-00c8-45bc-8731-66add87e5785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

