### PR TITLE
Prototype ARM GDB debug launcher for Chialisp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 *.vsix
 
 .fake
+.chialisp-debug
 runner/build
 debug/build
 wasm/target

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "activationEvents": [
         "onLanguage:chialisp",
         "onCommand:chialisp.startDebug",
+        "onCommand:chialisp.prepareArmGdbDebug",
         "onDebug",
         "onDebugResolve:chialisp",
         "workspaceContains:chialisp.json",
@@ -71,6 +72,11 @@
             {
                 "command": "chialisp.startDebug",
                 "title": "Start Chialisp Debug"
+            },
+            {
+                "command": "chialisp.prepareArmGdbDebug",
+                "title": "Prepare ARM GDB Chialisp Debug",
+                "category": "Chialisp"
             }
         ],
         "menus": {
@@ -78,6 +84,10 @@
                 {
                     "when": "resourceFilename =~ /\\.clsp$/ || resourceFilename =~ /\\.clvm$/",
                     "command": "chialisp.startDebug"
+                },
+                {
+                    "when": "resourceFilename =~ /\\.clsp$/ || resourceFilename =~ /\\.clvm$/",
+                    "command": "chialisp.prepareArmGdbDebug"
                 }
             ]
         },

--- a/schema/chialisp_properties.json
+++ b/schema/chialisp_properties.json
@@ -28,6 +28,14 @@
                     "program": {
                         "description": "Program to run (hex, clvm or clsp)",
                         "type": "string"
+                    },
+                    "run_args": {
+                        "description": "CLVM data to use as the argument environment for ARM GDB debug runs",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": ["()"]
                     }
                 }
             }

--- a/scripts/arm-gdb/gdb_stub_service.js
+++ b/scripts/arm-gdb/gdb_stub_service.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function parseArgs(argv) {
+    const result = {};
+    for (let i = 0; i < argv.length; i++) {
+        const key = argv[i];
+        if (!key.startsWith('--')) {
+            throw new Error(`unexpected argument ${key}`);
+        }
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith('--')) {
+            throw new Error(`missing value for ${key}`);
+        }
+        result[key.slice(2)] = value;
+        i += 1;
+    }
+    return result;
+}
+
+function tomlString(value) {
+    return JSON.stringify(value);
+}
+
+function writeFileIfChanged(filePath, content) {
+    try {
+        if (fs.readFileSync(filePath, 'utf8') === content) {
+            return;
+        }
+    } catch (_e) {
+        // Fall through to write.
+    }
+
+    fs.writeFileSync(filePath, content);
+}
+
+function helperCargoToml(clvmArmJitPath) {
+    return `[package]
+name = "chialisp_arm_gdb_helper"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+chialisp = "0.4.4"
+clvmr = "0.16.4"
+gdbstub = "0.7.1"
+clvm_to_arm_chialisp = { path = ${tomlString(path.join(clvmArmJitPath, 'clvm_to_arm_chialisp'))} }
+clvm_to_arm_emulate = { path = ${tomlString(path.join(clvmArmJitPath, 'clvm_to_arm_emulate'))} }
+clvm_to_arm_generate = { path = ${tomlString(path.join(clvmArmJitPath, 'clvm_to_arm_generate'))} }
+`;
+}
+
+function helperMainRs() {
+    return `use std::collections::HashMap;
+use std::fs;
+use std::net::TcpListener;
+use std::rc::Rc;
+
+use chialisp::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
+use chialisp::compiler::compiler::{compile_file, DefaultCompilerOpts};
+use chialisp::compiler::comptypes::CompilerOpts;
+use chialisp::compiler::debug::build_symbol_table_mut;
+use chialisp::compiler::dialect::AcceptedDialect;
+use chialisp::compiler::frontend::frontend;
+use chialisp::compiler::sexp::{decode_string, parse_sexp};
+use chialisp::compiler::srcloc::Srcloc;
+use clvmr::Allocator;
+
+use clvm_to_arm_chialisp::sexp_trait::{CreateChialispSExp, RcSExp, SrclocWrap};
+use clvm_to_arm_emulate::emu::Emu;
+use clvm_to_arm_emulate::emu_stub::run_stub;
+use clvm_to_arm_generate::code::{Program, TARGET_ADDR};
+
+#[derive(Debug)]
+struct Args {
+    program: String,
+    run_args: String,
+    elf_out: String,
+    port: u16,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut program = None;
+    let mut run_args = None;
+    let mut elf_out = None;
+    let mut port = None;
+    let mut iter = std::env::args().skip(1);
+
+    while let Some(key) = iter.next() {
+        let value = iter.next().ok_or_else(|| format!("missing value for {key}"))?;
+        match key.as_str() {
+            "--program" => program = Some(value),
+            "--run-args" => run_args = Some(value),
+            "--elf-out" => elf_out = Some(value),
+            "--port" => {
+                port = Some(value.parse::<u16>().map_err(|e| format!("invalid port: {e}"))?)
+            }
+            _ => return Err(format!("unknown argument {key}")),
+        }
+    }
+
+    Ok(Args {
+        program: program.ok_or_else(|| "missing --program".to_string())?,
+        run_args: run_args.ok_or_else(|| "missing --run-args".to_string())?,
+        elf_out: elf_out.ok_or_else(|| "missing --elf-out".to_string())?,
+        port: port.ok_or_else(|| "missing --port".to_string())?,
+    })
+}
+
+fn build_elf(program_path: &str, env: &str, elf_out: &str) -> Result<(Vec<u8>, Rc<HashMap<String, String>>), String> {
+    let program = fs::read_to_string(program_path)
+        .map_err(|e| format!("could not read chialisp program {program_path}: {e}"))?;
+    let srcloc = Srcloc::start(program_path);
+    let env_parsed = parse_sexp(srcloc.clone(), env.bytes())
+        .map_err(|(loc, e)| format!("failed to parse run_args at {loc}: {e}"))?;
+    let env_sexp = env_parsed
+        .first()
+        .ok_or_else(|| "run_args did not contain a CLVM value".to_string())?;
+
+    let mut allocator = Allocator::new();
+    let mut symbol_table = HashMap::new();
+    let runner: Rc<dyn TRunProgram> = Rc::new(DefaultProgramRunner::new());
+    let search_paths = vec![];
+    let opts = Rc::new(DefaultCompilerOpts::new(program_path))
+        .set_dialect(AcceptedDialect {
+            stepping: Some(23),
+            strict: true,
+            int_fix: true,
+            extra_numeric_constants: false,
+        })
+        .set_optimize(true)
+        .set_search_paths(&search_paths)
+        .set_frontend_opt(false);
+
+    let parsed_program = parse_sexp(srcloc.clone(), program.bytes())
+        .map_err(|(loc, e)| format!("failed to parse chialisp program at {loc}: {e}"))?;
+    let fe = frontend(opts.clone(), &parsed_program)
+        .map_err(|e| format!("failed to compose frontend program: {e:?}"))?;
+    let range_results: HashMap<String, SrclocWrap> = fe
+        .compileform()
+        .helpers
+        .iter()
+        .map(|h| (decode_string(h.name()), SrclocWrap(h.loc())))
+        .collect();
+
+    let compiled = compile_file(&mut allocator, runner, opts, &program, &mut symbol_table)
+        .map_err(|e| format!("failed to compile chialisp program: {e:?}"))?
+        .to_sexp();
+    build_symbol_table_mut(&mut symbol_table, &compiled);
+
+    let symbols = Rc::new(symbol_table);
+    let generator = Program::new::<CreateChialispSExp>(
+        range_results,
+        program_path,
+        elf_out,
+        RcSExp(Rc::new(compiled)),
+        RcSExp(env_sexp.clone()),
+        TARGET_ADDR,
+        symbols.clone(),
+    )?;
+
+    let elf_data = generator.to_elf(elf_out)?;
+    fs::write(elf_out, &elf_data.object_file)
+        .map_err(|e| format!("could not write elf output {elf_out}: {e}"))?;
+
+    Ok((elf_data.object_file, symbols))
+}
+
+fn main() -> Result<(), String> {
+    let args = parse_args()?;
+    let (elf_data, symbols) = build_elf(&args.program, &args.run_args, &args.elf_out)?;
+    let mut emu = Emu::new(&elf_data, TARGET_ADDR, symbols)
+        .map_err(|e| format!("could not create ARM emulator: {e:?}"))?;
+    let listener = TcpListener::bind(("127.0.0.1", args.port))
+        .map_err(|e| format!("could not bind GDB stub port {}: {e}", args.port))?;
+
+    println!("CHIALISP_GDB_STUB_READY {}", args.port);
+    let (stream, addr) = listener
+        .accept()
+        .map_err(|e| format!("could not accept GDB connection: {e}"))?;
+    eprintln!("Debugger connected from {addr}");
+
+    run_stub(Box::new(stream), &mut emu)
+}
+`;
+}
+
+function ensureHelperProject(workspace, clvmArmJitPath) {
+    const helperDir = path.join(workspace, '.chialisp-debug', 'arm-gdb-helper');
+    const srcDir = path.join(helperDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    writeFileIfChanged(path.join(helperDir, 'Cargo.toml'), helperCargoToml(clvmArmJitPath));
+    writeFileIfChanged(path.join(srcDir, 'main.rs'), helperMainRs());
+    return helperDir;
+}
+
+function runCargoHelper(helperDir, args) {
+    const runArgs = [
+        'run',
+        '--release',
+        '--manifest-path',
+        path.join(helperDir, 'Cargo.toml'),
+        '--',
+        '--program',
+        args.program,
+        '--run-args',
+        JSON.parse(args['run-args-json'])[0] || '()',
+        '--elf-out',
+        args['elf-out'],
+        '--port',
+        args.port,
+    ];
+
+    const child = spawn('cargo', runArgs, {
+        cwd: helperDir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+    });
+
+    child.stdout.on('data', (chunk) => process.stdout.write(chunk));
+    child.stderr.on('data', (chunk) => process.stderr.write(chunk));
+    child.on('error', (err) => {
+        console.error(`could not start cargo: ${err.message}`);
+        process.exitCode = 1;
+    });
+    child.on('exit', (code) => {
+        process.exit(code || 0);
+    });
+
+    process.on('SIGTERM', () => child.kill('SIGTERM'));
+    process.on('SIGINT', () => child.kill('SIGINT'));
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    for (const required of ['workspace', 'clvm-arm-jit', 'program', 'run-args-json', 'elf-out', 'port']) {
+        if (!args[required]) {
+            throw new Error(`missing --${required}`);
+        }
+    }
+
+    const helperDir = ensureHelperProject(args.workspace, args['clvm-arm-jit']);
+    runCargoHelper(helperDir, args);
+}
+
+try {
+    main();
+} catch (e) {
+    console.error(e && e.stack ? e.stack : String(e));
+    process.exit(1);
+}

--- a/scripts/arm-gdb/gdb_stub_service.js
+++ b/scripts/arm-gdb/gdb_stub_service.js
@@ -148,8 +148,20 @@ function startTcpBridge(wasm, args, built) {
         throw new Error(`invalid --port ${args.port}`);
     }
 
+    let shuttingDown = false;
     const server = net.createServer((socket) => {
         let stubId;
+        let exitCode = 0;
+        const shutdown = () => {
+            if (shuttingDown) {
+                return;
+            }
+
+            shuttingDown = true;
+            destroyStub(wasm, stubId);
+            server.close(() => process.exit(exitCode));
+            setTimeout(() => process.exit(exitCode), 1000).unref();
+        };
         const writeToSocket = (bytes) => {
             if (!socket.destroyed) {
                 socket.write(Buffer.from(bytes));
@@ -160,6 +172,7 @@ function startTcpBridge(wasm, args, built) {
             stubId = wasm.create_arm_gdb_stub(built.elf, built.symbolsJson, writeToSocket);
         } catch (e) {
             console.error(e && e.stack ? e.stack : String(e));
+            exitCode = 1;
             socket.destroy();
             return;
         }
@@ -169,17 +182,18 @@ function startTcpBridge(wasm, args, built) {
                 wasm.arm_gdb_stub_incoming_data(stubId, chunk);
             } catch (e) {
                 console.error(e && e.stack ? e.stack : String(e));
+                exitCode = 1;
                 socket.destroy();
             }
         });
 
         socket.on('close', () => {
-            destroyStub(wasm, stubId);
+            shutdown();
         });
 
         socket.on('error', (e) => {
             console.error(e && e.stack ? e.stack : String(e));
-            destroyStub(wasm, stubId);
+            exitCode = 1;
         });
     });
 

--- a/scripts/arm-gdb/gdb_stub_service.js
+++ b/scripts/arm-gdb/gdb_stub_service.js
@@ -53,6 +53,54 @@ function getRunArg(runArgsJson) {
     return '()';
 }
 
+function readChialispJson(workspace) {
+    const configPath = path.join(workspace, 'chialisp.json');
+    try {
+        return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch (e) {
+        if (e && e.code === 'ENOENT') {
+            return {};
+        }
+
+        throw e;
+    }
+}
+
+function getIncludePaths(workspace, programPath) {
+    const config = readChialispJson(workspace);
+    const configuredPaths = Array.isArray(config.include_paths) ? config.include_paths : [];
+    const includePaths = [path.dirname(programPath)];
+
+    for (const includePath of configuredPaths) {
+        if (typeof includePath !== 'string') {
+            continue;
+        }
+
+        if (path.isAbsolute(includePath)) {
+            includePaths.push(includePath);
+        } else {
+            includePaths.push(path.resolve(workspace, includePath));
+        }
+    }
+
+    return Array.from(new Set(includePaths));
+}
+
+function makeFileReader(workspace) {
+    return (filename) => {
+        const candidates = path.isAbsolute(filename) ? [filename] : [path.resolve(workspace, filename)];
+        for (const candidate of candidates) {
+            try {
+                return fs.readFileSync(candidate, 'utf8');
+            } catch (_e) {
+                // Try the next candidate.
+            }
+        }
+
+        return null;
+    };
+}
+
 function requiredArgs(args) {
     for (const required of ['workspace', 'program', 'run-args-json', 'elf-out', 'port']) {
         if (!args[required]) {
@@ -64,7 +112,15 @@ function requiredArgs(args) {
 function writeGeneratedElf(wasm, args) {
     const program = fs.readFileSync(args.program, 'utf8');
     const runArg = getRunArg(args['run-args-json']);
-    const built = wasm.arm_gdb_build_program(args.program, program, runArg, args['elf-out']);
+    const includePaths = getIncludePaths(args.workspace, args.program);
+    const built = wasm.arm_gdb_build_program(
+        args.program,
+        program,
+        runArg,
+        JSON.stringify(includePaths),
+        makeFileReader(args.workspace),
+        args['elf-out']
+    );
     const elf = Buffer.from(built.elf);
 
     fs.mkdirSync(path.dirname(args['elf-out']), { recursive: true });

--- a/scripts/arm-gdb/gdb_stub_service.js
+++ b/scripts/arm-gdb/gdb_stub_service.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const fs = require('fs');
+const net = require('net');
 const path = require('path');
-const { spawn } = require('child_process');
 
 function parseArgs(argv) {
     const result = {};
@@ -22,229 +22,129 @@ function parseArgs(argv) {
     return result;
 }
 
-function tomlString(value) {
-    return JSON.stringify(value);
-}
-
-function writeFileIfChanged(filePath, content) {
-    try {
-        if (fs.readFileSync(filePath, 'utf8') === content) {
-            return;
-        }
-    } catch (_e) {
-        // Fall through to write.
-    }
-
-    fs.writeFileSync(filePath, content);
-}
-
-function helperCargoToml(clvmArmJitPath) {
-    return `[package]
-name = "chialisp_arm_gdb_helper"
-version = "0.1.0"
-edition = "2024"
-
-[dependencies]
-chialisp = "0.4.4"
-clvmr = "0.16.4"
-gdbstub = "0.7.1"
-clvm_to_arm_chialisp = { path = ${tomlString(path.join(clvmArmJitPath, 'clvm_to_arm_chialisp'))} }
-clvm_to_arm_emulate = { path = ${tomlString(path.join(clvmArmJitPath, 'clvm_to_arm_emulate'))} }
-clvm_to_arm_generate = { path = ${tomlString(path.join(clvmArmJitPath, 'clvm_to_arm_generate'))} }
-`;
-}
-
-function helperMainRs() {
-    return `use std::collections::HashMap;
-use std::fs;
-use std::net::TcpListener;
-use std::rc::Rc;
-
-use chialisp::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
-use chialisp::compiler::compiler::{compile_file, DefaultCompilerOpts};
-use chialisp::compiler::comptypes::CompilerOpts;
-use chialisp::compiler::debug::build_symbol_table_mut;
-use chialisp::compiler::dialect::AcceptedDialect;
-use chialisp::compiler::frontend::frontend;
-use chialisp::compiler::sexp::{decode_string, parse_sexp};
-use chialisp::compiler::srcloc::Srcloc;
-use clvmr::Allocator;
-
-use clvm_to_arm_chialisp::sexp_trait::{CreateChialispSExp, RcSExp, SrclocWrap};
-use clvm_to_arm_emulate::emu::Emu;
-use clvm_to_arm_emulate::emu_stub::run_stub;
-use clvm_to_arm_generate::code::{Program, TARGET_ADDR};
-
-#[derive(Debug)]
-struct Args {
-    program: String,
-    run_args: String,
-    elf_out: String,
-    port: u16,
-}
-
-fn parse_args() -> Result<Args, String> {
-    let mut program = None;
-    let mut run_args = None;
-    let mut elf_out = None;
-    let mut port = None;
-    let mut iter = std::env::args().skip(1);
-
-    while let Some(key) = iter.next() {
-        let value = iter.next().ok_or_else(|| format!("missing value for {key}"))?;
-        match key.as_str() {
-            "--program" => program = Some(value),
-            "--run-args" => run_args = Some(value),
-            "--elf-out" => elf_out = Some(value),
-            "--port" => {
-                port = Some(value.parse::<u16>().map_err(|e| format!("invalid port: {e}"))?)
-            }
-            _ => return Err(format!("unknown argument {key}")),
-        }
-    }
-
-    Ok(Args {
-        program: program.ok_or_else(|| "missing --program".to_string())?,
-        run_args: run_args.ok_or_else(|| "missing --run-args".to_string())?,
-        elf_out: elf_out.ok_or_else(|| "missing --elf-out".to_string())?,
-        port: port.ok_or_else(|| "missing --port".to_string())?,
-    })
-}
-
-fn build_elf(program_path: &str, env: &str, elf_out: &str) -> Result<(Vec<u8>, Rc<HashMap<String, String>>), String> {
-    let program = fs::read_to_string(program_path)
-        .map_err(|e| format!("could not read chialisp program {program_path}: {e}"))?;
-    let srcloc = Srcloc::start(program_path);
-    let env_parsed = parse_sexp(srcloc.clone(), env.bytes())
-        .map_err(|(loc, e)| format!("failed to parse run_args at {loc}: {e}"))?;
-    let env_sexp = env_parsed
-        .first()
-        .ok_or_else(|| "run_args did not contain a CLVM value".to_string())?;
-
-    let mut allocator = Allocator::new();
-    let mut symbol_table = HashMap::new();
-    let runner: Rc<dyn TRunProgram> = Rc::new(DefaultProgramRunner::new());
-    let search_paths = vec![];
-    let opts = Rc::new(DefaultCompilerOpts::new(program_path))
-        .set_dialect(AcceptedDialect {
-            stepping: Some(23),
-            strict: true,
-            int_fix: true,
-            extra_numeric_constants: false,
-        })
-        .set_optimize(true)
-        .set_search_paths(&search_paths)
-        .set_frontend_opt(false);
-
-    let parsed_program = parse_sexp(srcloc.clone(), program.bytes())
-        .map_err(|(loc, e)| format!("failed to parse chialisp program at {loc}: {e}"))?;
-    let fe = frontend(opts.clone(), &parsed_program)
-        .map_err(|e| format!("failed to compose frontend program: {e:?}"))?;
-    let range_results: HashMap<String, SrclocWrap> = fe
-        .compileform()
-        .helpers
-        .iter()
-        .map(|h| (decode_string(h.name()), SrclocWrap(h.loc())))
-        .collect();
-
-    let compiled = compile_file(&mut allocator, runner, opts, &program, &mut symbol_table)
-        .map_err(|e| format!("failed to compile chialisp program: {e:?}"))?
-        .to_sexp();
-    build_symbol_table_mut(&mut symbol_table, &compiled);
-
-    let symbols = Rc::new(symbol_table);
-    let generator = Program::new::<CreateChialispSExp>(
-        range_results,
-        program_path,
-        elf_out,
-        RcSExp(Rc::new(compiled)),
-        RcSExp(env_sexp.clone()),
-        TARGET_ADDR,
-        symbols.clone(),
-    )?;
-
-    let elf_data = generator.to_elf(elf_out)?;
-    fs::write(elf_out, &elf_data.object_file)
-        .map_err(|e| format!("could not write elf output {elf_out}: {e}"))?;
-
-    Ok((elf_data.object_file, symbols))
-}
-
-fn main() -> Result<(), String> {
-    let args = parse_args()?;
-    let (elf_data, symbols) = build_elf(&args.program, &args.run_args, &args.elf_out)?;
-    let mut emu = Emu::new(&elf_data, TARGET_ADDR, symbols)
-        .map_err(|e| format!("could not create ARM emulator: {e:?}"))?;
-    let listener = TcpListener::bind(("127.0.0.1", args.port))
-        .map_err(|e| format!("could not bind GDB stub port {}: {e}", args.port))?;
-
-    println!("CHIALISP_GDB_STUB_READY {}", args.port);
-    let (stream, addr) = listener
-        .accept()
-        .map_err(|e| format!("could not accept GDB connection: {e}"))?;
-    eprintln!("Debugger connected from {addr}");
-
-    run_stub(Box::new(stream), &mut emu)
-}
-`;
-}
-
-function ensureHelperProject(workspace, clvmArmJitPath) {
-    const helperDir = path.join(workspace, '.chialisp-debug', 'arm-gdb-helper');
-    const srcDir = path.join(helperDir, 'src');
-    fs.mkdirSync(srcDir, { recursive: true });
-    writeFileIfChanged(path.join(helperDir, 'Cargo.toml'), helperCargoToml(clvmArmJitPath));
-    writeFileIfChanged(path.join(srcDir, 'main.rs'), helperMainRs());
-    return helperDir;
-}
-
-function runCargoHelper(helperDir, args) {
-    const runArgs = [
-        'run',
-        '--release',
-        '--manifest-path',
-        path.join(helperDir, 'Cargo.toml'),
-        '--',
-        '--program',
-        args.program,
-        '--run-args',
-        JSON.parse(args['run-args-json'])[0] || '()',
-        '--elf-out',
-        args['elf-out'],
-        '--port',
-        args.port,
+function loadWasmModule() {
+    const candidates = [
+        path.resolve(__dirname, '../../debug/build/clvm_tools_lsp.js'),
+        path.resolve(__dirname, '../../wasm/pkg/clvm_tools_lsp.js'),
     ];
 
-    const child = spawn('cargo', runArgs, {
-        cwd: helperDir,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: process.env,
-    });
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return require(candidate);
+        }
+    }
 
-    child.stdout.on('data', (chunk) => process.stdout.write(chunk));
-    child.stderr.on('data', (chunk) => process.stderr.write(chunk));
-    child.on('error', (err) => {
-        console.error(`could not start cargo: ${err.message}`);
-        process.exitCode = 1;
-    });
-    child.on('exit', (code) => {
-        process.exit(code || 0);
-    });
-
-    process.on('SIGTERM', () => child.kill('SIGTERM'));
-    process.on('SIGINT', () => child.kill('SIGINT'));
+    throw new Error(
+        `Could not find clvm_tools_lsp wasm package. Tried: ${candidates.join(', ')}. ` +
+        'Run `make` or `cd wasm && wasm-pack build --release --target nodejs` first.'
+    );
 }
 
-function main() {
-    const args = parseArgs(process.argv.slice(2));
-    for (const required of ['workspace', 'clvm-arm-jit', 'program', 'run-args-json', 'elf-out', 'port']) {
+function getRunArg(runArgsJson) {
+    const runArgs = JSON.parse(runArgsJson);
+    if (typeof runArgs === 'string') {
+        return runArgs;
+    }
+
+    if (Array.isArray(runArgs) && typeof runArgs[0] === 'string') {
+        return runArgs[0];
+    }
+
+    return '()';
+}
+
+function requiredArgs(args) {
+    for (const required of ['workspace', 'program', 'run-args-json', 'elf-out', 'port']) {
         if (!args[required]) {
             throw new Error(`missing --${required}`);
         }
     }
+}
 
-    const helperDir = ensureHelperProject(args.workspace, args['clvm-arm-jit']);
-    runCargoHelper(helperDir, args);
+function writeGeneratedElf(wasm, args) {
+    const program = fs.readFileSync(args.program, 'utf8');
+    const runArg = getRunArg(args['run-args-json']);
+    const built = wasm.arm_gdb_build_program(args.program, program, runArg, args['elf-out']);
+    const elf = Buffer.from(built.elf);
+
+    fs.mkdirSync(path.dirname(args['elf-out']), { recursive: true });
+    fs.writeFileSync(args['elf-out'], elf);
+
+    return {
+        elf,
+        symbolsJson: built.symbolsJson,
+    };
+}
+
+function destroyStub(wasm, stubId) {
+    if (stubId !== undefined) {
+        wasm.destroy_arm_gdb_stub(stubId);
+    }
+}
+
+function startTcpBridge(wasm, args, built) {
+    const port = Number.parseInt(args.port, 10);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+        throw new Error(`invalid --port ${args.port}`);
+    }
+
+    const server = net.createServer((socket) => {
+        let stubId;
+        const writeToSocket = (bytes) => {
+            if (!socket.destroyed) {
+                socket.write(Buffer.from(bytes));
+            }
+        };
+
+        try {
+            stubId = wasm.create_arm_gdb_stub(built.elf, built.symbolsJson, writeToSocket);
+        } catch (e) {
+            console.error(e && e.stack ? e.stack : String(e));
+            socket.destroy();
+            return;
+        }
+
+        socket.on('data', (chunk) => {
+            try {
+                wasm.arm_gdb_stub_incoming_data(stubId, chunk);
+            } catch (e) {
+                console.error(e && e.stack ? e.stack : String(e));
+                socket.destroy();
+            }
+        });
+
+        socket.on('close', () => {
+            destroyStub(wasm, stubId);
+        });
+
+        socket.on('error', (e) => {
+            console.error(e && e.stack ? e.stack : String(e));
+            destroyStub(wasm, stubId);
+        });
+    });
+
+    server.on('error', (e) => {
+        console.error(e && e.stack ? e.stack : String(e));
+        process.exit(1);
+    });
+
+    server.listen(port, '127.0.0.1', () => {
+        console.log(`CHIALISP_GDB_STUB_READY ${port}`);
+    });
+
+    process.on('SIGTERM', () => server.close(() => process.exit(0)));
+    process.on('SIGINT', () => server.close(() => process.exit(0)));
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    requiredArgs(args);
+
+    process.chdir(args.workspace);
+
+    const wasm = loadWasmModule();
+    const built = writeGeneratedElf(wasm, args);
+    startTcpBridge(wasm, args, built);
 }
 
 try {

--- a/scripts/arm-gdb/gdb_stub_service.js
+++ b/scripts/arm-gdb/gdb_stub_service.js
@@ -102,7 +102,7 @@ function makeFileReader(workspace) {
 }
 
 function requiredArgs(args) {
-    for (const required of ['workspace', 'program', 'run-args-json', 'elf-out', 'port']) {
+    for (const required of ['workspace', 'program', 'run-args-json', 'elf-out', 'synthetic-source-out', 'port']) {
         if (!args[required]) {
             throw new Error(`missing --${required}`);
         }
@@ -122,12 +122,16 @@ function writeGeneratedElf(wasm, args) {
         args['elf-out']
     );
     const elf = Buffer.from(built.elf);
+    const syntheticSource = built.syntheticSource || '';
 
     fs.mkdirSync(path.dirname(args['elf-out']), { recursive: true });
     fs.writeFileSync(args['elf-out'], elf);
+    fs.mkdirSync(path.dirname(args['synthetic-source-out']), { recursive: true });
+    fs.writeFileSync(args['synthetic-source-out'], syntheticSource, 'utf8');
 
     return {
         elf,
+        syntheticSource,
         symbolsJson: built.symbolsJson,
     };
 }

--- a/src/armGdbDebug.ts
+++ b/src/armGdbDebug.ts
@@ -23,6 +23,7 @@ interface ArmGdbContext {
     webGdbDir: string;
     buildDir: string;
     elfPath: string;
+    syntheticSourcePath: string;
     nodeWrapperPath: string;
     port: number;
     runArgs: string[];
@@ -214,6 +215,7 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
     const buildDir = path.join(workDir, 'build');
     const safeBaseName = path.basename(programPath).replace(/[^a-zA-Z0-9_.-]/g, '_');
     const elfPath = path.join(buildDir, `${safeBaseName}.arm.elf`);
+    const syntheticSourcePath = `${elfPath}.clsp`;
     const port = await reservePort();
 
     await fs.promises.mkdir(buildDir, { recursive: true });
@@ -228,6 +230,7 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
         webGdbDir,
         buildDir,
         elfPath,
+        syntheticSourcePath,
         nodeWrapperPath,
         port,
         runArgs,
@@ -251,6 +254,8 @@ function startStubService(context: vscode.ExtensionContext, armContext: ArmGdbCo
         JSON.stringify(armContext.runArgs),
         '--elf-out',
         armContext.elfPath,
+        '--synthetic-source-out',
+        armContext.syntheticSourcePath,
         '--port',
         armContext.port.toString(),
     ];
@@ -319,9 +324,11 @@ async function writeLaunchJson(armContext: ArmGdbContext): Promise<vscode.DebugC
     const vscodeDir = path.join(armContext.workspaceRoot, '.vscode');
     const launchPath = path.join(vscodeDir, 'launch.json');
     const elfRel = toWorkspaceSlashPath(armContext.workspaceRoot, armContext.elfPath);
+    const syntheticSourceRel = toWorkspaceSlashPath(armContext.workspaceRoot, armContext.syntheticSourcePath);
     const programRel = toWorkspaceSlashPath(armContext.workspaceRoot, armContext.programPath);
     const workspaceVar = '${workspaceFolder}';
     const elfWorkspacePath = `${workspaceVar}/${elfRel}`;
+    const syntheticSourceWorkspacePath = `${workspaceVar}/${syntheticSourceRel}`;
     const guestElfPath = `/mnt/${elfRel}`;
     const runnerPath = `${workspaceVar}/${toWorkspaceSlashPath(armContext.workspaceRoot, path.join(armContext.webGdbDir, 'src', 'runner.js'))}`;
     const nodeWrapperPath = `${workspaceVar}/${toWorkspaceSlashPath(armContext.workspaceRoot, armContext.nodeWrapperPath)}`;
@@ -334,6 +341,8 @@ async function writeLaunchJson(armContext: ArmGdbContext): Promise<vscode.DebugC
         quoteArg(workspaceVar),
         '--import-file',
         quoteArg(elfWorkspacePath),
+        '--import-file',
+        quoteArg(syntheticSourceWorkspacePath),
         '--interpreter=mi',
     ].join(' ');
 

--- a/src/armGdbDebug.ts
+++ b/src/armGdbDebug.ts
@@ -260,7 +260,10 @@ function startStubService(context: vscode.ExtensionContext, armContext: ArmGdbCo
             cwd: armContext.workspaceRoot,
             env: {
                 ...process.env,
+                // Electron uses these exact environment variable names to run as Node.
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 ELECTRON_RUN_AS_NODE: '1',
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1',
             },
         });

--- a/src/armGdbDebug.ts
+++ b/src/armGdbDebug.ts
@@ -23,6 +23,7 @@ interface ArmGdbContext {
     webGdbDir: string;
     buildDir: string;
     elfPath: string;
+    nodeWrapperPath: string;
     port: number;
     runArgs: string[];
 }
@@ -40,6 +41,10 @@ function getOutputChannel(): vscode.OutputChannel {
 
 function quoteArg(value: string): string {
     return `"${value.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function quoteSh(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function toWorkspaceSlashPath(workspaceRoot: string, filePath: string): string {
@@ -115,6 +120,34 @@ async function ensureRepo(repoPath: string, repoUrl: string, parentDir: string):
     await runProcess('git', ['-C', repoPath, 'submodule', 'update', '--init', '--recursive'], parentDir);
 }
 
+async function writeNodeWrapper(workDir: string): Promise<string> {
+    const wrapperPath = path.join(workDir, process.platform === 'win32' ? 'vscode-node.cmd' : 'vscode-node');
+    const executable = process.execPath;
+
+    if (process.platform === 'win32') {
+        const content = [
+            '@echo off',
+            'set ELECTRON_RUN_AS_NODE=1',
+            'set ATOM_SHELL_INTERNAL_RUN_AS_NODE=1',
+            `"${executable}" %*`,
+            '',
+        ].join('\r\n');
+        await fs.promises.writeFile(wrapperPath, content, 'utf8');
+    } else {
+        const content = [
+            '#!/bin/sh',
+            'export ELECTRON_RUN_AS_NODE=1',
+            'export ATOM_SHELL_INTERNAL_RUN_AS_NODE=1',
+            `exec ${quoteSh(executable)} "$@"`,
+            '',
+        ].join('\n');
+        await fs.promises.writeFile(wrapperPath, content, { encoding: 'utf8', mode: 0o755 });
+        await fs.promises.chmod(wrapperPath, 0o755);
+    }
+
+    return wrapperPath;
+}
+
 async function readChialispJson(jsonPath: string): Promise<ChialispJson> {
     try {
         const content = await fs.promises.readFile(jsonPath, 'utf8');
@@ -184,6 +217,7 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
     const port = await reservePort();
 
     await fs.promises.mkdir(buildDir, { recursive: true });
+    const nodeWrapperPath = await writeNodeWrapper(workDir);
     await ensureRepo(webGdbDir, WEB_GDB_NODE_REPO, workDir);
 
     return {
@@ -194,6 +228,7 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
         webGdbDir,
         buildDir,
         elfPath,
+        nodeWrapperPath,
         port,
         runArgs,
     };
@@ -223,7 +258,11 @@ function startStubService(context: vscode.ExtensionContext, armContext: ArmGdbCo
     return new Promise((resolve, reject) => {
         const child = spawn(process.execPath, args, {
             cwd: armContext.workspaceRoot,
-            env: process.env,
+            env: {
+                ...process.env,
+                ELECTRON_RUN_AS_NODE: '1',
+                ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1',
+            },
         });
         runningStub = child;
 
@@ -282,6 +321,7 @@ async function writeLaunchJson(armContext: ArmGdbContext): Promise<vscode.DebugC
     const elfWorkspacePath = `${workspaceVar}/${elfRel}`;
     const guestElfPath = `/mnt/${elfRel}`;
     const runnerPath = `${workspaceVar}/${toWorkspaceSlashPath(armContext.workspaceRoot, path.join(armContext.webGdbDir, 'src', 'runner.js'))}`;
+    const nodeWrapperPath = `${workspaceVar}/${toWorkspaceSlashPath(armContext.workspaceRoot, armContext.nodeWrapperPath)}`;
     const name = `Chialisp ARM GDB: ${path.basename(armContext.programPath)}`;
     const miDebuggerArgs = [
         quoteArg(runnerPath),
@@ -303,7 +343,7 @@ async function writeLaunchJson(armContext: ArmGdbContext): Promise<vscode.DebugC
         // cppdbg requires this exact launch.json spelling.
         // eslint-disable-next-line @typescript-eslint/naming-convention
         MIMode: 'gdb',
-        miDebuggerPath: 'node',
+        miDebuggerPath: nodeWrapperPath,
         miDebuggerArgs,
         stopAtEntry: true,
         externalConsole: false,

--- a/src/armGdbDebug.ts
+++ b/src/armGdbDebug.ts
@@ -1,0 +1,405 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as path from 'path';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+
+import { extensionName, publisher } from './constants';
+import { log } from './logger';
+
+const WEB_GDB_NODE_REPO = 'https://github.com/prozacchiwawa/web-gdb-node.git';
+const CLVM_ARM_JIT_REPO = 'https://github.com/prozacchiwawa/clvm_arm_jit.git';
+const DEBUG_WORK_DIR = '.chialisp-debug';
+
+interface ChialispJson {
+    run_args?: string[] | string; // eslint-disable-line @typescript-eslint/naming-convention
+    [key: string]: unknown;
+}
+
+interface ArmGdbContext {
+    folder: vscode.WorkspaceFolder;
+    programPath: string;
+    workspaceRoot: string;
+    workDir: string;
+    webGdbDir: string;
+    armJitDir: string;
+    buildDir: string;
+    elfPath: string;
+    port: number;
+    runArgs: string[];
+}
+
+let runningStub: ChildProcessWithoutNullStreams | undefined;
+let outputChannel: vscode.OutputChannel | undefined;
+
+function getOutputChannel(): vscode.OutputChannel {
+    if (!outputChannel) {
+        outputChannel = vscode.window.createOutputChannel('Chialisp ARM GDB');
+    }
+
+    return outputChannel;
+}
+
+function quoteArg(value: string): string {
+    return `"${value.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function toWorkspaceSlashPath(workspaceRoot: string, filePath: string): string {
+    return path.relative(workspaceRoot, filePath).split(path.sep).join('/');
+}
+
+function executableExists(filePath: string): boolean {
+    try {
+        fs.accessSync(filePath, fs.constants.X_OK);
+        return true;
+    } catch (_e) {
+        return false;
+    }
+}
+
+function repoExists(repoPath: string): boolean {
+    return fs.existsSync(path.join(repoPath, '.git'));
+}
+
+function normalizeRunArgs(value: unknown): string[] | undefined {
+    if (typeof value === 'string') {
+        return [value];
+    }
+
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+        return value as string[];
+    }
+
+    return undefined;
+}
+
+function parseJsonWithLineComments(content: string): any {
+    return JSON.parse(content.replace(/^\s*\/\/.*$/gm, ''));
+}
+
+function runProcess(command: string, args: string[], cwd: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd,
+            env: process.env,
+        });
+        let output = '';
+
+        child.stdout.on('data', (chunk: Buffer) => {
+            const text = chunk.toString('utf8');
+            output += text;
+            getOutputChannel().append(text);
+        });
+
+        child.stderr.on('data', (chunk: Buffer) => {
+            const text = chunk.toString('utf8');
+            output += text;
+            getOutputChannel().append(text);
+        });
+
+        child.once('error', reject);
+        child.once('exit', (code) => {
+            if (code === 0) {
+                resolve();
+            } else {
+                reject(new Error(`${command} ${args.join(' ')} exited with ${code}: ${output}`));
+            }
+        });
+    });
+}
+
+async function ensureRepo(repoPath: string, repoUrl: string, parentDir: string): Promise<void> {
+    if (!repoExists(repoPath)) {
+        await runProcess('git', ['clone', '--recurse-submodules', repoUrl, repoPath], parentDir);
+        return;
+    }
+
+    await runProcess('git', ['-C', repoPath, 'submodule', 'update', '--init', '--recursive'], parentDir);
+}
+
+async function readChialispJson(jsonPath: string): Promise<ChialispJson> {
+    try {
+        const content = await fs.promises.readFile(jsonPath, 'utf8');
+        return JSON.parse(content) as ChialispJson;
+    } catch (e: any) {
+        if (e && e.code === 'ENOENT') {
+            return {};
+        }
+
+        throw e;
+    }
+}
+
+async function getRunArgs(workspaceRoot: string): Promise<string[] | undefined> {
+    const jsonPath = path.join(workspaceRoot, 'chialisp.json');
+    const chialispJson = await readChialispJson(jsonPath);
+    const existing = normalizeRunArgs(chialispJson.run_args);
+    if (existing && existing.length > 0) {
+        return existing;
+    }
+
+    const input = await vscode.window.showInputBox({
+        prompt: 'CLVM data to use as arguments for this ARM GDB debug run',
+        placeHolder: '(99 103)',
+        value: '()',
+        ignoreFocusOut: true,
+    });
+
+    if (input === undefined) {
+        return undefined;
+    }
+
+    chialispJson.run_args = [input];
+    await fs.promises.writeFile(jsonPath, JSON.stringify(chialispJson, null, 4) + '\n', 'utf8');
+    return [input];
+}
+
+function reservePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            if (!address || typeof address === 'string') {
+                server.close(() => reject(new Error('could not reserve local TCP port')));
+                return;
+            }
+
+            const port = address.port;
+            server.close(() => resolve(port));
+        });
+    });
+}
+
+async function prepareContext(folder: vscode.WorkspaceFolder, programPath: string): Promise<ArmGdbContext | undefined> {
+    const workspaceRoot = folder.uri.fsPath;
+    const runArgs = await getRunArgs(workspaceRoot);
+    if (!runArgs) {
+        return undefined;
+    }
+
+    const workDir = path.join(workspaceRoot, DEBUG_WORK_DIR);
+    const webGdbDir = path.join(workDir, 'web-gdb-node');
+    const armJitDir = path.join(workDir, 'clvm_arm_jit');
+    const buildDir = path.join(workDir, 'build');
+    const safeBaseName = path.basename(programPath).replace(/[^a-zA-Z0-9_.-]/g, '_');
+    const elfPath = path.join(buildDir, `${safeBaseName}.arm.elf`);
+    const port = await reservePort();
+
+    await fs.promises.mkdir(buildDir, { recursive: true });
+    await ensureRepo(webGdbDir, WEB_GDB_NODE_REPO, workDir);
+    await ensureRepo(armJitDir, CLVM_ARM_JIT_REPO, workDir);
+
+    return {
+        folder,
+        programPath,
+        workspaceRoot,
+        workDir,
+        webGdbDir,
+        armJitDir,
+        buildDir,
+        elfPath,
+        port,
+        runArgs,
+    };
+}
+
+function startStubService(context: vscode.ExtensionContext, armContext: ArmGdbContext): Promise<void> {
+    if (runningStub) {
+        runningStub.kill();
+        runningStub = undefined;
+    }
+
+    const servicePath = path.join(context.extensionPath, 'scripts', 'arm-gdb', 'gdb_stub_service.js');
+    const args = [
+        servicePath,
+        '--workspace',
+        armContext.workspaceRoot,
+        '--clvm-arm-jit',
+        armContext.armJitDir,
+        '--program',
+        armContext.programPath,
+        '--run-args-json',
+        JSON.stringify(armContext.runArgs),
+        '--elf-out',
+        armContext.elfPath,
+        '--port',
+        armContext.port.toString(),
+    ];
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, args, {
+            cwd: armContext.workspaceRoot,
+            env: process.env,
+        });
+        runningStub = child;
+
+        let settled = false;
+        const timeout = setTimeout(() => {
+            if (!settled) {
+                settled = true;
+                reject(new Error('timed out waiting for the ARM GDB stub to become ready'));
+            }
+        }, 10 * 60 * 1000);
+
+        const finishReady = () => {
+            if (!settled) {
+                settled = true;
+                clearTimeout(timeout);
+                resolve();
+            }
+        };
+
+        const fail = (message: string) => {
+            if (!settled) {
+                settled = true;
+                clearTimeout(timeout);
+                reject(new Error(message));
+            }
+        };
+
+        child.stdout.on('data', (chunk: Buffer) => {
+            const text = chunk.toString('utf8');
+            getOutputChannel().append(text);
+            if (text.includes('CHIALISP_GDB_STUB_READY')) {
+                finishReady();
+            }
+        });
+
+        child.stderr.on('data', (chunk: Buffer) => {
+            getOutputChannel().append(chunk.toString('utf8'));
+        });
+
+        child.once('error', (err) => fail(err.message));
+        child.once('exit', (code) => {
+            runningStub = undefined;
+            if (code !== 0) {
+                fail(`ARM GDB stub exited with ${code}`);
+            }
+        });
+    });
+}
+
+async function writeLaunchJson(armContext: ArmGdbContext): Promise<vscode.DebugConfiguration> {
+    const vscodeDir = path.join(armContext.workspaceRoot, '.vscode');
+    const launchPath = path.join(vscodeDir, 'launch.json');
+    const elfRel = toWorkspaceSlashPath(armContext.workspaceRoot, armContext.elfPath);
+    const programRel = toWorkspaceSlashPath(armContext.workspaceRoot, armContext.programPath);
+    const workspaceVar = '${workspaceFolder}';
+    const elfWorkspacePath = `${workspaceVar}/${elfRel}`;
+    const guestElfPath = `/mnt/${elfRel}`;
+    const runnerPath = `${workspaceVar}/${toWorkspaceSlashPath(armContext.workspaceRoot, path.join(armContext.webGdbDir, 'src', 'runner.js'))}`;
+    const name = `Chialisp ARM GDB: ${path.basename(armContext.programPath)}`;
+    const miDebuggerArgs = [
+        quoteArg(runnerPath),
+        '--gdb-server',
+        `localhost:${armContext.port}`,
+        '--workspace',
+        quoteArg(workspaceVar),
+        '--import-file',
+        quoteArg(elfWorkspacePath),
+        '--interpreter=mi',
+    ].join(' ');
+
+    const configuration: vscode.DebugConfiguration = {
+        name,
+        type: 'cppdbg',
+        request: 'launch',
+        program: elfWorkspacePath,
+        cwd: workspaceVar,
+        MIMode: 'gdb',
+        miDebuggerPath: 'node',
+        miDebuggerArgs,
+        stopAtEntry: true,
+        externalConsole: false,
+        customLaunchSetupCommands: [
+            { text: '-gdb-set architecture arm', description: 'Select ARM architecture' },
+            { text: `-file-exec-and-symbols ${guestElfPath}`, description: 'Load generated Chialisp ARM ELF symbols' },
+            { text: '-target-select remote /dev/ttyS1', description: 'Connect to web-gdb-node serial GDB bridge' },
+        ],
+        launchCompleteCommand: 'None',
+        chialispProgram: `${workspaceVar}/${programRel}`,
+        chialispRunArgs: armContext.runArgs,
+    };
+
+    let launchJson: any = {
+        version: '0.2.0',
+        configurations: [],
+    };
+
+    try {
+        launchJson = parseJsonWithLineComments(await fs.promises.readFile(launchPath, 'utf8'));
+    } catch (e: any) {
+        if (!e || e.code !== 'ENOENT') {
+            throw e;
+        }
+    }
+
+    if (!Array.isArray(launchJson.configurations)) {
+        launchJson.configurations = [];
+    }
+
+    launchJson.configurations = launchJson.configurations.filter((item: any) => item && item.name !== name);
+    launchJson.configurations.push(configuration);
+
+    await fs.promises.mkdir(vscodeDir, { recursive: true });
+    await fs.promises.writeFile(launchPath, JSON.stringify(launchJson, null, 4) + '\n', 'utf8');
+    return configuration;
+}
+
+export function armGdbDebugActivate(context: vscode.ExtensionContext) {
+    context.subscriptions.push({
+        dispose: () => {
+            if (runningStub) {
+                runningStub.kill();
+                runningStub = undefined;
+            }
+        },
+    });
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(`${extensionName}.prepareArmGdbDebug`, async (uri?: vscode.Uri) => {
+            const selectedUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+            if (!selectedUri) {
+                throw new Error('could not get uri for active text editor');
+            }
+
+            const folder = vscode.workspace.getWorkspaceFolder(selectedUri);
+            if (!folder) {
+                throw new Error('No workspace root for open files');
+            }
+
+            const selfExtension = vscode.extensions.getExtension(`${publisher}.${extensionName}`);
+            if (!selfExtension) {
+                throw new Error('no extension matches our id');
+            }
+
+            const channel = getOutputChannel();
+            channel.show(true);
+
+            const configuration = await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: 'Preparing Chialisp ARM GDB debug launch',
+                cancellable: false,
+            }, async (progress) => {
+                progress.report({ message: 'Downloading helper repositories' });
+                const armContext = await prepareContext(folder, selectedUri.fsPath);
+                if (!armContext) {
+                    return undefined;
+                }
+
+                progress.report({ message: 'Building ELF and starting GDB stub' });
+                await startStubService(context, armContext);
+
+                progress.report({ message: 'Writing .vscode/launch.json' });
+                return writeLaunchJson(armContext);
+            });
+
+            if (configuration) {
+                void vscode.window.showInformationMessage(
+                    `Wrote ${configuration.name} and started the ARM GDB stub. Start that launch configuration to enter gdb-multiarch.`
+                );
+            }
+        })
+    );
+}

--- a/src/armGdbDebug.ts
+++ b/src/armGdbDebug.ts
@@ -307,6 +307,8 @@ async function writeLaunchJson(armContext: ArmGdbContext): Promise<vscode.DebugC
         request: 'launch',
         program: elfWorkspacePath,
         cwd: workspaceVar,
+        // cppdbg requires this exact launch.json spelling.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         MIMode: 'gdb',
         miDebuggerPath: 'node',
         miDebuggerArgs,

--- a/src/armGdbDebug.ts
+++ b/src/armGdbDebug.ts
@@ -8,7 +8,6 @@ import { extensionName, publisher } from './constants';
 import { log } from './logger';
 
 const WEB_GDB_NODE_REPO = 'https://github.com/prozacchiwawa/web-gdb-node.git';
-const CLVM_ARM_JIT_REPO = 'https://github.com/prozacchiwawa/clvm_arm_jit.git';
 const DEBUG_WORK_DIR = '.chialisp-debug';
 
 interface ChialispJson {
@@ -22,7 +21,6 @@ interface ArmGdbContext {
     workspaceRoot: string;
     workDir: string;
     webGdbDir: string;
-    armJitDir: string;
     buildDir: string;
     elfPath: string;
     port: number;
@@ -180,7 +178,6 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
 
     const workDir = path.join(workspaceRoot, DEBUG_WORK_DIR);
     const webGdbDir = path.join(workDir, 'web-gdb-node');
-    const armJitDir = path.join(workDir, 'clvm_arm_jit');
     const buildDir = path.join(workDir, 'build');
     const safeBaseName = path.basename(programPath).replace(/[^a-zA-Z0-9_.-]/g, '_');
     const elfPath = path.join(buildDir, `${safeBaseName}.arm.elf`);
@@ -188,7 +185,6 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
 
     await fs.promises.mkdir(buildDir, { recursive: true });
     await ensureRepo(webGdbDir, WEB_GDB_NODE_REPO, workDir);
-    await ensureRepo(armJitDir, CLVM_ARM_JIT_REPO, workDir);
 
     return {
         folder,
@@ -196,7 +192,6 @@ async function prepareContext(folder: vscode.WorkspaceFolder, programPath: strin
         workspaceRoot,
         workDir,
         webGdbDir,
-        armJitDir,
         buildDir,
         elfPath,
         port,
@@ -215,8 +210,6 @@ function startStubService(context: vscode.ExtensionContext, armContext: ArmGdbCo
         servicePath,
         '--workspace',
         armContext.workspaceRoot,
-        '--clvm-arm-jit',
-        armContext.armJitDir,
         '--program',
         armContext.programPath,
         '--run-args-json',
@@ -384,7 +377,7 @@ export function armGdbDebugActivate(context: vscode.ExtensionContext) {
                 title: 'Preparing Chialisp ARM GDB debug launch',
                 cancellable: false,
             }, async (progress) => {
-                progress.report({ message: 'Downloading helper repositories' });
+                progress.report({ message: 'Downloading web-gdb-node' });
                 const armContext = await prepareContext(folder, selectedUri.fsPath);
                 if (!armContext) {
                     return undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import {
 import { TextDecoder, TextEncoder } from 'util';
 import { languageActivate, languageDeactivate } from './lsp';
 import { debuggerActivate, debuggerDeactivate } from './dbg';
+import { armGdbDebugActivate } from './armGdbDebug';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the c`ommand is executed
@@ -47,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.workspace.registerTextDocumentContentProvider('chialisp-schema', new SchemaProvider());
     languageActivate(context);
     debuggerActivate(context);
+    armGdbDebugActivate(context);
 }
 
 // this method is called when your extension is deactivated

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "chialisp"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2bd39688477367251f60da4dfd8de93416adcb35cc479bde52dd35caae4c2"
+checksum = "e7eb5d3b740c534c601413b8c3c7ff4222626f8d54e27449392cfe215dc55479"
 dependencies = [
  "binascii",
  "chia-bls 0.42.1",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.2"
+name = "ahash"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "armv4t_emu"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7c3101cedc9937fdd4f1ee991dc707411001a649159a8e9032422bb67f804f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -19,9 +40,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
@@ -31,9 +52,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "binascii"
@@ -49,9 +70,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -76,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
@@ -88,21 +109,25 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chia-bls"
@@ -117,23 +142,23 @@ dependencies = [
  "hkdf",
  "linked-hash-map",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "chia-bls"
-version = "0.30.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a74b1699d07115c71c081826608e3fb73f2aed94f9060fa09d074a95cfc93ab"
+checksum = "48f85777c396aa0ed9837add53ef22fe6b153d861b8a344dd57a4d493dd6c5c4"
 dependencies = [
  "blst",
- "chia-sha2 0.30.0",
- "chia-traits 0.30.0",
+ "chia-sha2 0.42.1",
+ "chia-traits 0.42.1",
  "hex",
  "hkdf",
  "linked-hash-map",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -147,9 +172,18 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114775b95f24b296047dc9c91e43834aa651c7c25bb2bbae05d23d79c9c777b"
+checksum = "f06500dc809a916fa0c70f5219b8b79a598462382a4ddca91ef1a3cb32b826ce"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
+name = "chia-sha2"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eabeed0e07a8656ff9e7597988eb21b48af6a1997dfca47164dd1544c80fcba"
 dependencies = [
  "sha2",
 ]
@@ -162,18 +196,18 @@ checksum = "52463c56cdf35aac55ecb35ffc0a615f0780f33f144503957e83f5b1ad92da3c"
 dependencies = [
  "chia-sha2 0.28.2",
  "chia_streamable_macro 0.28.2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "chia-traits"
-version = "0.30.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143545b13658929fce2e770a499fd4755f04a4d5f6459dc76a79068ae192a8c5"
+checksum = "e012b4d5336fe5457be5157a655208a9671a41bd41c3fc72ac59c56073c21c18"
 dependencies = [
- "chia-sha2 0.30.0",
- "chia_streamable_macro 0.30.0",
- "thiserror",
+ "chia-sha2 0.42.1",
+ "chia_streamable_macro 0.42.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -185,35 +219,35 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.30.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bd4fbc3f05375c267ee4cb2a4a1bf8125fa0d817e57d7b141993c35994c751"
+checksum = "9567c7e8fe38b640aeeb4af3c0e04f4f6938a438a2506b39bb93d39e0a23e1a9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "chialisp"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5f2217b8d1a7575ca7889a2f655294c02607cabfe9029e2ed8de13104edeca"
+checksum = "f0f2bd39688477367251f60da4dfd8de93416adcb35cc479bde52dd35caae4c2"
 dependencies = [
  "binascii",
- "chia-bls 0.30.0",
+ "chia-bls 0.42.1",
  "clvmr",
  "do-notation",
- "getrandom 0.2.9",
+ "getrandom 0.2.17",
  "hashlink",
  "hex",
- "indoc 2.0.5",
+ "indoc 2.0.7",
  "js-sys",
  "lazy_static",
  "num",
@@ -231,13 +265,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "clvm_to_arm_chialisp"
+version = "0.1.0"
+source = "git+https://github.com/prozacchiwawa/clvm_arm_jit.git#1a85a9f769e605f1803e3e25b515b2c356c41c4f"
+dependencies = [
+ "chialisp",
+ "clvm_to_arm_emulate",
+ "clvm_to_arm_generate",
+ "clvmr",
+ "tempfile",
+]
+
+[[package]]
+name = "clvm_to_arm_emulate"
+version = "0.1.0"
+source = "git+https://github.com/prozacchiwawa/clvm_arm_jit.git#1a85a9f769e605f1803e3e25b515b2c356c41c4f"
+dependencies = [
+ "armv4t_emu",
+ "clvm_to_arm_generate",
+ "clvmr",
+ "elf_rs",
+ "gdbstub",
+ "gdbstub_arch",
+ "gimli",
+ "hex",
+ "num-bigint",
+ "sha2",
+ "target-lexicon 0.11.2",
+]
+
+[[package]]
+name = "clvm_to_arm_generate"
+version = "0.1.0"
+source = "git+https://github.com/prozacchiwawa/clvm_arm_jit.git#1a85a9f769e605f1803e3e25b515b2c356c41c4f"
+dependencies = [
+ "armv4t_emu",
+ "clvmr",
+ "elf_rs",
+ "faerie",
+ "gimli",
+ "hex",
+ "num-bigint",
+ "sha2",
+ "target-lexicon 0.11.2",
+]
+
+[[package]]
 name = "clvm_tools_lsp"
 version = "1.2.4"
 dependencies = [
  "chialisp",
+ "clvm_to_arm_chialisp",
+ "clvm_to_arm_emulate",
+ "clvm_to_arm_generate",
  "clvmr",
  "debug_types",
- "getrandom 0.2.9",
+ "getrandom 0.2.17",
  "indoc 1.0.9",
  "js-sys",
  "lazy_static",
@@ -254,14 +337,14 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf14f44f7c6b1d7972753cdd66f6afae38b117b752e6d1256b6f532dc3a0d304"
+checksum = "d2174ea916c818da7aa500ec9dfeb891b2510b160efb20deec292710df24844b"
 dependencies = [
  "bitvec",
  "bumpalo",
  "chia-bls 0.28.2",
- "chia-sha2 0.28.2",
+ "chia-sha2 0.34.0",
  "hex",
  "hex-literal",
  "k256",
@@ -273,7 +356,7 @@ dependencies = [
  "rand",
  "sha1",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -284,27 +367,27 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -341,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -360,6 +443,17 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -380,6 +474,16 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "elf_rs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894d710b6b07dae25ce69f9227ec2ffa3a3f71dc7f071acea3e1928ab4aeafdf"
+dependencies = [
+ "bitflags 2.11.1",
+ "num-traits",
 ]
 
 [[package]]
@@ -413,47 +517,80 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "faerie"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "94ba4f799fe731896ead36d6cbfda83233573badc50fad12dc1c4b40c46ba7b3"
+dependencies = [
+ "goblin",
+ "indexmap 1.9.3",
+ "log",
+ "scroll",
+ "string-interner",
+ "target-lexicon 0.11.2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.4"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -465,10 +602,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "gdbstub"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "log",
+ "managed",
+ "num-traits",
+ "pastey",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c02bfe7bd65f42bcda751456869dfa1eb2bd1c36e309b9ec27f4888d41cf258"
+dependencies = [
+ "gdbstub",
+ "num-traits",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -477,34 +638,57 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669cdc3826f69a51d3f8fc3f86de81c2378110254f678b8407977736122057a4"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "group"
@@ -519,33 +703,63 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -578,23 +792,134 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -605,15 +930,18 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -655,10 +983,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linked-hash-map"
@@ -668,15 +1002,21 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lsp-server"
@@ -704,16 +1044,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.1"
+name = "managed"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -795,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -805,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "p256"
@@ -822,6 +1168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pkcs8"
@@ -847,10 +1199,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
+name = "plain"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "primeorder"
@@ -873,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -887,17 +1267,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
- "target-lexicon",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -932,14 +1318,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -949,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -960,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
@@ -976,11 +1362,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -989,15 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "ryu"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -1006,6 +1386,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1023,45 +1423,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.197"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1088,13 +1506,19 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
@@ -1107,6 +1531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,20 +1547,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.5.0"
+name = "stable_deref_trait"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string-interner"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383196d1876517ee6f9f0864d1fc1070331b803335d3c6daaa04bbcccd823c08"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.9.1",
+ "serde",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1141,18 +1610,24 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1164,7 +1639,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1175,7 +1659,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1188,25 +1683,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
+name = "tinystr"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
@@ -1214,61 +1704,59 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "utf8_iter"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1282,17 +1770,26 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1319,7 +1816,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1354,7 +1851,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1389,7 +1886,41 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -1404,78 +1935,27 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -1487,13 +1967,104 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags 2.4.2",
+ "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -1506,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -1516,21 +2087,124 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.7.0"
+name = "yoke"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib"]
 path = "src/mod.rs"
 
 [dependencies]
-chialisp = "0.4.4"
-clvmr = "0.16.4"
+chialisp = "=0.4.4"
+clvmr = "=0.16.4"
 clvm_to_arm_chialisp = { git = "https://github.com/prozacchiwawa/clvm_arm_jit.git" }
 clvm_to_arm_emulate = { git = "https://github.com/prozacchiwawa/clvm_arm_jit.git" }
 clvm_to_arm_generate = { git = "https://github.com/prozacchiwawa/clvm_arm_jit.git" }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -17,8 +17,11 @@ crate-type = ["cdylib"]
 path = "src/mod.rs"
 
 [dependencies]
-chialisp = "=0.4.1"
-clvmr = "0.16.0"
+chialisp = "0.4.4"
+clvmr = "0.16.4"
+clvm_to_arm_chialisp = { git = "https://github.com/prozacchiwawa/clvm_arm_jit.git" }
+clvm_to_arm_emulate = { git = "https://github.com/prozacchiwawa/clvm_arm_jit.git" }
+clvm_to_arm_generate = { git = "https://github.com/prozacchiwawa/clvm_arm_jit.git" }
 wasm-bindgen = "=0.2.100"
 wasm-bindgen-test = "=0.3.50"
 js-sys = "0.3.60"

--- a/wasm/src/arm_gdb.rs
+++ b/wasm/src/arm_gdb.rs
@@ -133,7 +133,7 @@ fn build_elf(
     include_paths: Vec<String>,
     file_reader: js_sys::Function,
     elf_output_name: &str,
-) -> Result<(Vec<u8>, Rc<HashMap<String, String>>), String> {
+) -> Result<(Vec<u8>, String, Rc<HashMap<String, String>>), String> {
     let srcloc = Srcloc::start(program_path);
     let env_parsed = parse_sexp(srcloc.clone(), run_arg.bytes())
         .map_err(|(loc, e)| format!("failed to parse run_args at {loc}: {e}"))?;
@@ -189,7 +189,7 @@ fn build_elf(
     )?;
     let elf_data = generator.to_elf(elf_output_name)?;
 
-    Ok((elf_data.object_file, symbols))
+    Ok((elf_data.object_file, elf_data.synthetic_source, symbols))
 }
 
 #[wasm_bindgen]
@@ -206,7 +206,7 @@ pub fn arm_gdb_build_program(
         .dyn_ref::<js_sys::Function>()
         .ok_or_else(|| js_error("file_reader must be a function"))?
         .clone();
-    let (elf, symbols) = build_elf(
+    let (elf, synthetic_source, symbols) = build_elf(
         &program_path,
         &program,
         &run_arg,
@@ -227,6 +227,11 @@ pub fn arm_gdb_build_program(
         &result,
         &JsValue::from_str("symbolsJson"),
         &JsValue::from_str(&symbols_json),
+    )?;
+    Reflect::set(
+        &result,
+        &JsValue::from_str("syntheticSource"),
+        &JsValue::from_str(&synthetic_source),
     )?;
 
     Ok(result.into())

--- a/wasm/src/arm_gdb.rs
+++ b/wasm/src/arm_gdb.rs
@@ -2,16 +2,17 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io;
 use std::mem::swap;
+use std::path::Path;
 use std::rc::Rc;
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 use chialisp::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
-use chialisp::compiler::compiler::{compile_file, DefaultCompilerOpts};
-use chialisp::compiler::comptypes::CompilerOpts;
+use chialisp::compiler::compiler::{compile_file, DefaultCompilerOpts, STANDARD_MACROS};
+use chialisp::compiler::comptypes::{CompileErr, CompilerOpts, HasCompilerOptsDelegation};
 use chialisp::compiler::debug::build_symbol_table_mut;
-use chialisp::compiler::dialect::AcceptedDialect;
+use chialisp::compiler::dialect::{AcceptedDialect, DialectDescription, KNOWN_DIALECTS};
 use chialisp::compiler::frontend::frontend;
 use chialisp::compiler::sexp::{decode_string, parse_sexp};
 use chialisp::compiler::srcloc::Srcloc;
@@ -28,6 +29,88 @@ thread_local! {
     static ARM_GDB_STUBS: RefCell<HashMap<i32, RefCell<CallbackGdbStub>>> = {
         RefCell::new(HashMap::new())
     };
+}
+
+#[derive(Clone)]
+struct ArmGdbCompilerOpts {
+    opts: Rc<dyn CompilerOpts>,
+    include_paths: Vec<String>,
+    file_reader: js_sys::Function,
+    known_dialects: Rc<HashMap<String, DialectDescription>>,
+}
+
+impl ArmGdbCompilerOpts {
+    fn read_file(&self, name: &str) -> Option<String> {
+        self.file_reader
+            .call1(&JsValue::null(), &JsValue::from_str(name))
+            .ok()
+            .and_then(|value| {
+                if value.is_null() || value.is_undefined() {
+                    None
+                } else {
+                    value.as_string()
+                }
+            })
+    }
+}
+
+impl HasCompilerOptsDelegation for ArmGdbCompilerOpts {
+    fn compiler_opts(&self) -> Rc<dyn CompilerOpts> {
+        self.opts.clone()
+    }
+
+    fn update_compiler_opts<F: FnOnce(Rc<dyn CompilerOpts>) -> Rc<dyn CompilerOpts>>(
+        &self,
+        f: F,
+    ) -> Rc<dyn CompilerOpts> {
+        Rc::new(ArmGdbCompilerOpts {
+            opts: f(self.opts.clone()),
+            ..self.clone()
+        })
+    }
+
+    fn override_read_new_file(
+        &self,
+        inc_from: String,
+        filename: String,
+    ) -> Result<(String, Vec<u8>), CompileErr> {
+        if filename == "*macros*" {
+            return Ok((filename, STANDARD_MACROS.clone().into()));
+        } else if let Some(content) = self.known_dialects.get(&filename) {
+            return Ok((filename, content.content.as_bytes().to_vec()));
+        }
+
+        if Path::new(&filename).is_absolute() {
+            if let Some(content) = self.read_file(&filename) {
+                return Ok((filename, content.into_bytes()));
+            }
+        }
+
+        for include_path in self.include_paths.iter() {
+            if let Some(candidate) = Path::new(include_path)
+                .join(&filename)
+                .to_str()
+                .map(|s| s.to_string())
+            {
+                if let Some(content) = self.read_file(&candidate) {
+                    return Ok((candidate, content.into_bytes()));
+                }
+            }
+        }
+
+        Err(CompileErr(
+            Srcloc::start(&inc_from),
+            format!("could not find {filename} to include"),
+        ))
+    }
+
+    fn override_set_search_paths(&self, new_paths: &[String]) -> Rc<dyn CompilerOpts> {
+        Rc::new(ArmGdbCompilerOpts {
+            opts: self.opts.set_search_paths(new_paths),
+            include_paths: new_paths.to_vec(),
+            ..self.clone()
+        })
+    }
 }
 
 fn next_arm_gdb_id() -> i32 {
@@ -47,6 +130,8 @@ fn build_elf(
     program_path: &str,
     program: &str,
     run_arg: &str,
+    include_paths: Vec<String>,
+    file_reader: js_sys::Function,
     elf_output_name: &str,
 ) -> Result<(Vec<u8>, Rc<HashMap<String, String>>), String> {
     let srcloc = Srcloc::start(program_path);
@@ -59,7 +144,6 @@ fn build_elf(
     let mut allocator = Allocator::new();
     let mut symbol_table = HashMap::new();
     let runner: Rc<dyn TRunProgram> = Rc::new(DefaultProgramRunner::new());
-    let search_paths = vec![];
     let opts = Rc::new(DefaultCompilerOpts::new(program_path))
         .set_dialect(AcceptedDialect {
             stepping: Some(23),
@@ -68,8 +152,14 @@ fn build_elf(
             extra_numeric_constants: false,
         })
         .set_optimize(true)
-        .set_search_paths(&search_paths)
+        .set_search_paths(&include_paths)
         .set_frontend_opt(false);
+    let opts: Rc<dyn CompilerOpts> = Rc::new(ArmGdbCompilerOpts {
+        opts,
+        include_paths,
+        file_reader,
+        known_dialects: Rc::new(KNOWN_DIALECTS.clone()),
+    });
 
     let parsed_program = parse_sexp(srcloc.clone(), program.bytes())
         .map_err(|(loc, e)| format!("failed to parse chialisp program at {loc}: {e}"))?;
@@ -107,10 +197,24 @@ pub fn arm_gdb_build_program(
     program_path: String,
     program: String,
     run_arg: String,
+    include_paths_json: String,
+    file_reader: &JsValue,
     elf_output_name: String,
 ) -> Result<JsValue, JsValue> {
-    let (elf, symbols) =
-        build_elf(&program_path, &program, &run_arg, &elf_output_name).map_err(js_error)?;
+    let include_paths: Vec<String> = serde_json::from_str(&include_paths_json).map_err(js_error)?;
+    let file_reader = file_reader
+        .dyn_ref::<js_sys::Function>()
+        .ok_or_else(|| js_error("file_reader must be a function"))?
+        .clone();
+    let (elf, symbols) = build_elf(
+        &program_path,
+        &program,
+        &run_arg,
+        include_paths,
+        file_reader,
+        &elf_output_name,
+    )
+    .map_err(js_error)?;
     let symbols_json = serde_json::to_string(symbols.as_ref()).map_err(js_error)?;
     let result = Object::new();
 

--- a/wasm/src/arm_gdb.rs
+++ b/wasm/src/arm_gdb.rs
@@ -1,0 +1,219 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io;
+use std::mem::swap;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+use chialisp::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
+use chialisp::compiler::compiler::{compile_file, DefaultCompilerOpts};
+use chialisp::compiler::comptypes::CompilerOpts;
+use chialisp::compiler::debug::build_symbol_table_mut;
+use chialisp::compiler::dialect::AcceptedDialect;
+use chialisp::compiler::frontend::frontend;
+use chialisp::compiler::sexp::{decode_string, parse_sexp};
+use chialisp::compiler::srcloc::Srcloc;
+use clvm_to_arm_chialisp::sexp_trait::{CreateChialispSExp, RcSExp, SrclocWrap};
+use clvm_to_arm_emulate::emu_stub::CallbackGdbStub;
+use clvm_to_arm_generate::code::{Program, TARGET_ADDR};
+use clvmr::Allocator;
+use js_sys::{Object, Reflect, Uint8Array};
+
+thread_local! {
+    static NEXT_ARM_GDB_ID: RefCell<i32> = {
+        RefCell::new(0)
+    };
+    static ARM_GDB_STUBS: RefCell<HashMap<i32, RefCell<CallbackGdbStub>>> = {
+        RefCell::new(HashMap::new())
+    };
+}
+
+fn next_arm_gdb_id() -> i32 {
+    NEXT_ARM_GDB_ID.with(|next| {
+        let mut borrowed = next.borrow_mut();
+        let result = *borrowed;
+        *borrowed += 1;
+        result
+    })
+}
+
+fn js_error(message: impl ToString) -> JsValue {
+    JsValue::from_str(&message.to_string())
+}
+
+fn build_elf(
+    program_path: &str,
+    program: &str,
+    run_arg: &str,
+    elf_output_name: &str,
+) -> Result<(Vec<u8>, Rc<HashMap<String, String>>), String> {
+    let srcloc = Srcloc::start(program_path);
+    let env_parsed = parse_sexp(srcloc.clone(), run_arg.bytes())
+        .map_err(|(loc, e)| format!("failed to parse run_args at {loc}: {e}"))?;
+    let env_sexp = env_parsed
+        .first()
+        .ok_or_else(|| "run_args did not contain a CLVM value".to_string())?;
+
+    let mut allocator = Allocator::new();
+    let mut symbol_table = HashMap::new();
+    let runner: Rc<dyn TRunProgram> = Rc::new(DefaultProgramRunner::new());
+    let search_paths = vec![];
+    let opts = Rc::new(DefaultCompilerOpts::new(program_path))
+        .set_dialect(AcceptedDialect {
+            stepping: Some(23),
+            strict: true,
+            int_fix: true,
+            extra_numeric_constants: false,
+        })
+        .set_optimize(true)
+        .set_search_paths(&search_paths)
+        .set_frontend_opt(false);
+
+    let parsed_program = parse_sexp(srcloc.clone(), program.bytes())
+        .map_err(|(loc, e)| format!("failed to parse chialisp program at {loc}: {e}"))?;
+    let fe = frontend(opts.clone(), &parsed_program)
+        .map_err(|e| format!("failed to compose frontend program: {e:?}"))?;
+    let range_results: HashMap<String, SrclocWrap> = fe
+        .compileform()
+        .helpers
+        .iter()
+        .map(|h| (decode_string(h.name()), SrclocWrap(h.loc())))
+        .collect();
+
+    let compiled = compile_file(&mut allocator, runner, opts, program, &mut symbol_table)
+        .map_err(|e| format!("failed to compile chialisp program: {e:?}"))?
+        .to_sexp();
+    build_symbol_table_mut(&mut symbol_table, &compiled);
+
+    let symbols = Rc::new(symbol_table);
+    let generator = Program::new::<CreateChialispSExp>(
+        range_results,
+        program_path,
+        elf_output_name,
+        RcSExp(Rc::new(compiled)),
+        RcSExp(env_sexp.clone()),
+        TARGET_ADDR,
+        symbols.clone(),
+    )?;
+    let elf_data = generator.to_elf(elf_output_name)?;
+
+    Ok((elf_data.object_file, symbols))
+}
+
+#[wasm_bindgen]
+pub fn arm_gdb_build_program(
+    program_path: String,
+    program: String,
+    run_arg: String,
+    elf_output_name: String,
+) -> Result<JsValue, JsValue> {
+    let (elf, symbols) =
+        build_elf(&program_path, &program, &run_arg, &elf_output_name).map_err(js_error)?;
+    let symbols_json = serde_json::to_string(symbols.as_ref()).map_err(js_error)?;
+    let result = Object::new();
+
+    Reflect::set(
+        &result,
+        &JsValue::from_str("elf"),
+        &Uint8Array::from(elf.as_slice()).into(),
+    )?;
+    Reflect::set(
+        &result,
+        &JsValue::from_str("symbolsJson"),
+        &JsValue::from_str(&symbols_json),
+    )?;
+
+    Ok(result.into())
+}
+
+#[wasm_bindgen]
+pub fn create_arm_gdb_stub(
+    elf: Vec<u8>,
+    symbols_json: String,
+    output: &JsValue,
+) -> Result<i32, JsValue> {
+    let output_fn = output
+        .dyn_ref::<js_sys::Function>()
+        .ok_or_else(|| js_error("output must be a function"))?
+        .clone();
+    let symbols: HashMap<String, String> = serde_json::from_str(&symbols_json).map_err(js_error)?;
+    let stub = CallbackGdbStub::new(
+        &elf,
+        Rc::new(symbols),
+        Box::new(move |bytes| {
+            output_fn
+                .call1(&JsValue::null(), &Uint8Array::from(bytes).into())
+                .map(|_| ())
+                .map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        err.as_string()
+                            .unwrap_or_else(|| "gdb output callback failed".to_string()),
+                    )
+                })
+        }),
+    )
+    .map_err(js_error)?;
+    let new_id = next_arm_gdb_id();
+
+    ARM_GDB_STUBS.with(|stubs| {
+        stubs.replace_with(|stubs| {
+            let mut work_stubs = HashMap::new();
+            swap(&mut work_stubs, stubs);
+            work_stubs.insert(new_id, RefCell::new(stub));
+            work_stubs
+        })
+    });
+
+    Ok(new_id)
+}
+
+#[wasm_bindgen]
+pub fn arm_gdb_stub_incoming_data(stub_id: i32, data: Vec<u8>) -> Result<(), JsValue> {
+    ARM_GDB_STUBS.with(|stubs| {
+        let borrowed = stubs.borrow();
+        let stub = borrowed
+            .get(&stub_id)
+            .ok_or_else(|| js_error(format!("unknown ARM GDB stub id {stub_id}")))?;
+        stub.borrow_mut().incoming_data(&data).map_err(js_error)
+    })
+}
+
+#[wasm_bindgen]
+pub fn arm_gdb_stub_interrupt(stub_id: i32) -> Result<(), JsValue> {
+    ARM_GDB_STUBS.with(|stubs| {
+        let borrowed = stubs.borrow();
+        let stub = borrowed
+            .get(&stub_id)
+            .ok_or_else(|| js_error(format!("unknown ARM GDB stub id {stub_id}")))?;
+        stub.borrow_mut().interrupt().map_err(js_error)
+    })
+}
+
+#[wasm_bindgen]
+pub fn arm_gdb_stub_disconnected(stub_id: i32) -> Result<Option<String>, JsValue> {
+    ARM_GDB_STUBS.with(|stubs| {
+        let borrowed = stubs.borrow();
+        let stub = borrowed
+            .get(&stub_id)
+            .ok_or_else(|| js_error(format!("unknown ARM GDB stub id {stub_id}")))?;
+        Ok(stub
+            .borrow()
+            .disconnected()
+            .map(|reason| format!("{reason:?}")))
+    })
+}
+
+#[wasm_bindgen]
+pub fn destroy_arm_gdb_stub(stub_id: i32) {
+    ARM_GDB_STUBS.with(|stubs| {
+        stubs.replace_with(|stubs| {
+            let mut work_stubs = HashMap::new();
+            swap(&mut work_stubs, stubs);
+            work_stubs.remove(&stub_id);
+            work_stubs
+        })
+    });
+}

--- a/wasm/src/arm_gdb.rs
+++ b/wasm/src/arm_gdb.rs
@@ -177,7 +177,8 @@ pub fn arm_gdb_stub_incoming_data(stub_id: i32, data: Vec<u8>) -> Result<(), JsV
         let stub = borrowed
             .get(&stub_id)
             .ok_or_else(|| js_error(format!("unknown ARM GDB stub id {stub_id}")))?;
-        stub.borrow_mut().incoming_data(&data).map_err(js_error)
+        let result = stub.borrow_mut().incoming_data(&data).map_err(js_error);
+        result
     })
 }
 
@@ -188,7 +189,8 @@ pub fn arm_gdb_stub_interrupt(stub_id: i32) -> Result<(), JsValue> {
         let stub = borrowed
             .get(&stub_id)
             .ok_or_else(|| js_error(format!("unknown ARM GDB stub id {stub_id}")))?;
-        stub.borrow_mut().interrupt().map_err(js_error)
+        let result = stub.borrow_mut().interrupt().map_err(js_error);
+        result
     })
 }
 
@@ -199,10 +201,11 @@ pub fn arm_gdb_stub_disconnected(stub_id: i32) -> Result<Option<String>, JsValue
         let stub = borrowed
             .get(&stub_id)
             .ok_or_else(|| js_error(format!("unknown ARM GDB stub id {stub_id}")))?;
-        Ok(stub
+        let result = Ok(stub
             .borrow()
             .disconnected()
-            .map(|reason| format!("{reason:?}")))
+            .map(|reason| format!("{reason:?}")));
+        result
     })
 }
 

--- a/wasm/src/dbg/compopts.rs
+++ b/wasm/src/dbg/compopts.rs
@@ -2,19 +2,18 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 
-use clvmr::allocator::Allocator;
-
 use crate::interfaces::{IFileReader, ILogWriter};
 use crate::lsp::patch::{compute_comment_lines, get_bytes, split_text};
 use crate::lsp::types::DocData;
-use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 use chialisp::compiler::compiler::{compile_pre_forms, STANDARD_MACROS};
-use chialisp::compiler::comptypes::{CompileErr, CompilerOpts, HasCompilerOptsDelegation};
+use chialisp::compiler::comptypes::{
+    CompileErr, CompilerOpts, CompilerOutput, HasCompilerOptsDelegation,
+};
 use chialisp::compiler::dialect::{DialectDescription, KNOWN_DIALECTS};
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
-use chialisp::compiler::CompileContextWrapper;
+use chialisp::compiler::BasicCompileContext;
 
 #[derive(Clone)]
 pub struct DbgCompilerOpts {
@@ -62,19 +61,12 @@ impl HasCompilerOptsDelegation for DbgCompilerOpts {
 
     fn override_compile_program(
         &self,
-        allocator: &mut Allocator,
-        runner: Rc<dyn TRunProgram>,
+        context: &mut BasicCompileContext,
         sexp: Rc<SExp>,
-        symbol_table: &mut HashMap<String, String>,
-    ) -> Result<SExp, CompileErr> {
+    ) -> Result<CompilerOutput, CompileErr> {
         let me = Rc::new(self.clone());
-        let mut context_wrapper = CompileContextWrapper::new(
-            allocator,
-            runner,
-            symbol_table,
-            get_optimizer(&Srcloc::start(&self.filename()), me.clone())?,
-        );
-        compile_pre_forms(&mut context_wrapper.context, me, &[sexp])
+        context.optimizer = get_optimizer(&Srcloc::start(&self.filename()), me.clone())?;
+        compile_pre_forms(context, me, &[sexp])
     }
 }
 

--- a/wasm/src/dbg/obj.rs
+++ b/wasm/src/dbg/obj.rs
@@ -18,9 +18,7 @@ use chialisp::classic::clvm_tools::comp_input::RunAndCompileInputData;
 use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 use chialisp::classic::platform::argparse::ArgumentValue;
 use chialisp::compiler::cldb::hex_to_modern_sexp;
-use chialisp::compiler::cldb_hierarchy::{
-    HierarchialRunner, HierarchialStepResult, RunPurpose,
-};
+use chialisp::compiler::cldb_hierarchy::{HierarchialRunner, HierarchialStepResult, RunPurpose};
 #[cfg(test)]
 use chialisp::compiler::compiler::DefaultCompilerOpts;
 use chialisp::compiler::comptypes::{CompileErr, CompileForm, CompilerOpts, HelperForm};

--- a/wasm/src/dbg/obj.rs
+++ b/wasm/src/dbg/obj.rs
@@ -398,7 +398,10 @@ fn test_simple_find_location_classic_symbols_1() {
         "(mod (X)\n  (defun fact (X) (if (= X 1) 1 (* X (fact (- X 1)))))\n  (fact 5)\n  )";
     let parsed = parse_sexp(Srcloc::start("fact.clsp"), program.bytes()).expect("should parse");
     let opts = Rc::new(DefaultCompilerOpts::new("fact.clsp"));
-    let compiled = frontend(opts, &parsed).expect("should compile");
+    let compiled = frontend(opts, &parsed)
+        .expect("should compile")
+        .compileform()
+        .clone();
     let breakpoint_spec = SourceBreakpoint {
         column: Some(0),
         condition: None,
@@ -632,7 +635,7 @@ fn read_program_data(
             frontend(opts.clone(), &source_and_content.source_parsed).map_err(compile_err_map)?;
 
         inputs.source = Some(source_and_content);
-        inputs.compiled = Ok(Some(frontend_compiled));
+        inputs.compiled = Ok(Some(frontend_compiled.compileform().clone()));
     }
 
     let mut parsed_program = if inputs.is_hex {

--- a/wasm/src/lsp/compopts.rs
+++ b/wasm/src/lsp/compopts.rs
@@ -4,19 +4,18 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use clvmr::allocator::Allocator;
-
 use crate::interfaces::{IFileReader, ILogWriter};
 use crate::lsp::patch::{compute_comment_lines, split_text};
 use crate::lsp::types::DocData;
-use chialisp::classic::clvm_tools::stages::stage_0::TRunProgram;
 use chialisp::compiler::compiler::{compile_pre_forms, STANDARD_MACROS};
-use chialisp::compiler::comptypes::{CompileErr, CompilerOpts, HasCompilerOptsDelegation};
+use chialisp::compiler::comptypes::{
+    CompileErr, CompilerOpts, CompilerOutput, HasCompilerOptsDelegation,
+};
 use chialisp::compiler::dialect::{DialectDescription, KNOWN_DIALECTS};
 use chialisp::compiler::optimize::get_optimizer;
 use chialisp::compiler::sexp::SExp;
 use chialisp::compiler::srcloc::Srcloc;
-use chialisp::compiler::CompileContextWrapper;
+use chialisp::compiler::BasicCompileContext;
 
 use super::patch::get_bytes;
 
@@ -77,19 +76,12 @@ impl HasCompilerOptsDelegation for LSPCompilerOpts {
 
     fn override_compile_program(
         &self,
-        allocator: &mut Allocator,
-        runner: Rc<dyn TRunProgram>,
+        context: &mut BasicCompileContext,
         sexp: Rc<SExp>,
-        symbol_table: &mut HashMap<String, String>,
-    ) -> Result<SExp, CompileErr> {
+    ) -> Result<CompilerOutput, CompileErr> {
         let me = Rc::new(self.clone());
-        let mut context_wrapper = CompileContextWrapper::new(
-            allocator,
-            runner,
-            symbol_table,
-            get_optimizer(&Srcloc::start(&self.filename()), me.clone())?,
-        );
-        compile_pre_forms(&mut context_wrapper.context, me, &[sexp])
+        context.optimizer = get_optimizer(&Srcloc::start(&self.filename()), me.clone())?;
+        compile_pre_forms(context, me, &[sexp])
     }
 }
 

--- a/wasm/src/lsp/parse.rs
+++ b/wasm/src/lsp/parse.rs
@@ -131,6 +131,7 @@ pub fn recover_scopes(ourfile: &str, text: &[Rc<Vec<u8>>], fe: &CompileForm) -> 
             HelperForm::Defconstant(c) => {
                 toplevel_args.insert(Rc::new(SExp::Atom(c.loc.clone(), c.name.clone())));
             }
+            HelperForm::Defnamespace(_) | HelperForm::Defnsref(_) => {}
         }
 
         let f = h.loc().file.clone();
@@ -592,7 +593,10 @@ fn get_test_program_for_scope_tests(file: &str, prog: &[Rc<Vec<u8>>]) -> Compile
     let sl = Srcloc::start(file);
     let parsed = parse_sexp(sl, DocVecByteIter::new(prog)).expect("should parse");
     let opts = Rc::new(DefaultCompilerOpts::new(file));
-    frontend(opts, &parsed).expect("should compile")
+    frontend(opts, &parsed)
+        .expect("should compile")
+        .compileform()
+        .clone()
 }
 
 #[cfg(test)]

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -11,7 +11,7 @@ use chialisp::compiler::clvm::sha256tree_from_atom;
 use chialisp::compiler::comptypes::{
     BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm,
 };
-use chialisp::compiler::frontend::{compile_bodyform, compile_helperform};
+use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult};
 use chialisp::compiler::prims::primquote;
 use chialisp::compiler::sexp::{enlist, parse_sexp, SExp};
 use chialisp::compiler::srcloc::Srcloc;
@@ -103,6 +103,11 @@ fn compile_helperform_with_loose_defconstant(
     opts: Rc<dyn CompilerOpts>,
     parsed: Rc<SExp>,
 ) -> Result<Option<HelperForm>, CompileErr> {
+    let pick_first_helper = |result: Result<Option<HelperFormResult>, CompileErr>| {
+        result.map(|maybe_result| {
+            maybe_result.and_then(|helper_result| helper_result.new_helpers.into_iter().next())
+        })
+    };
     let is_defconstant = |sexp: &SExp| {
         if let SExp::Atom(_, name) = sexp {
             return name == b"defconstant";
@@ -131,13 +136,13 @@ fn compile_helperform_with_loose_defconstant(
                 // Try by enwrapping the body in quote so it can act as an
                 // expression to the parser.  Other kinds of errors will still
                 // go through.
-                return compile_helperform(opts, Rc::new(amended_instr));
+                return pick_first_helper(compile_helperform(opts, Rc::new(amended_instr)));
             }
         }
     }
 
     // Not a proper list so not the kind of thing we're looking for.
-    compile_helperform(opts, parsed)
+    pick_first_helper(compile_helperform(opts, parsed))
 }
 
 pub fn reparse_subset(

--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -8,9 +8,7 @@ use crate::lsp::types::{
     DocPosition, DocRange, Hash, IncludeData, IncludeKind, ParseScope, ReparsedExp, ReparsedHelper,
 };
 use chialisp::compiler::clvm::sha256tree_from_atom;
-use chialisp::compiler::comptypes::{
-    BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm,
-};
+use chialisp::compiler::comptypes::{BodyForm, CompileErr, CompileForm, CompilerOpts, HelperForm};
 use chialisp::compiler::frontend::{compile_bodyform, compile_helperform, HelperFormResult};
 use chialisp::compiler::prims::primquote;
 use chialisp::compiler::sexp::{enlist, parse_sexp, SExp};

--- a/wasm/src/lsp/semtok.rs
+++ b/wasm/src/lsp/semtok.rs
@@ -537,6 +537,7 @@ pub fn build_semantic_tokens(
                     mac.program.exp.clone(),
                 );
             }
+            HelperForm::Defnamespace(_) | HelperForm::Defnsref(_) => {}
         }
     }
 

--- a/wasm/src/mod.rs
+++ b/wasm/src/mod.rs
@@ -6,6 +6,7 @@ extern crate lazy_static;
 extern crate indoc;
 
 pub mod api;
+mod arm_gdb;
 mod dbg;
 mod interfaces;
 pub mod lsp;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Chialisp command that prepares an ARM GDB debug run for the active Chialisp/CLVM file
- clone/update web-gdb-node with submodules into `.chialisp-debug`
- prompt for missing `chialisp.json` `run_args`, build an ARM ELF via new exports in the existing `clvm_tools_lsp` wasm crate, start a JS TCP bridge backed by wasm-wrapped `CallbackGdbStub`, and write a `cppdbg` launch configuration using web-gdb-node's gdb-multiarch runner
- wire `clvm_arm_jit` crates into the wasm crate and update existing compiler/LSP call sites for the required Chialisp compiler API version
- use the workspace `chialisp.json` `include_paths` when compiling the ARM ELF, with JS providing include file contents to the wasm compiler
- generate a `.chialisp-debug/vscode-node` wrapper so cpptools can run web-gdb-node through VS Code's own Electron/Node runtime instead of requiring `node` on PATH
- write the synthesized CLVM source to `<generated elf>.clsp` and import it into web-gdb alongside the ELF so DWARF source references can resolve
- exit the ARM GDB stub service when the debugger TCP socket disconnects, cleaning up the wasm stub and returning a nonzero status if the session ended due to a bridge error

## Testing
- `node --check scripts/arm-gdb/gdb_stub_service.js`
- `npm run compile`
- `npm run lint` (passes with existing warning-only findings)
- `cargo +stable check --manifest-path wasm/Cargo.toml --target wasm32-unknown-unknown`
- `cargo +stable test --manifest-path wasm/Cargo.toml`
- `RUSTUP_TOOLCHAIN=stable wasm-pack build --release --target nodejs`
- Node smoke test loading `wasm/pkg/clvm_tools_lsp.js`, calling `arm_gdb_build_program` with `/workspace/test/fact.clsp` plus `/workspace/test/include`, and writing returned `syntheticSource` to `/tmp/fact.elf.clsp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a176eae-d688-4507-857b-9339b6e1278d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a176eae-d688-4507-857b-9339b6e1278d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

