### PR TITLE
Fix LSP diagnostics for imported function calls

### DIFF
--- a/wasm/src/lsp/reparse.rs
+++ b/wasm/src/lsp/reparse.rs
@@ -476,9 +476,20 @@ pub fn reparse_subset(
 }
 
 // Only the top scope is relevant for now.
-fn find_function_in_scopes(prims: &[Vec<u8>], scopes: &ParseScope, name: &SExp) -> bool {
+fn find_function_in_scopes<F>(
+    prims: &[Vec<u8>],
+    scopes: &ParseScope,
+    frontend: &CompileForm,
+    name: &SExp,
+    imported_helper_resolver: &mut F,
+) -> bool
+where
+    F: FnMut(&CompileForm, &[u8]) -> bool,
+{
     if let SExp::Atom(_, a) = name {
-        scopes.functions.contains(name) || prims.iter().any(|p| p == a)
+        scopes.functions.contains(name)
+            || prims.iter().any(|p| p == a)
+            || imported_helper_resolver(frontend, a)
     } else {
         false
     }
@@ -488,8 +499,23 @@ fn find_function_in_scopes(prims: &[Vec<u8>], scopes: &ParseScope, name: &SExp) 
 pub fn check_live_helper_calls(
     prims: &[Vec<u8>],
     scopes: &ParseScope,
+    frontend: &CompileForm,
     exp: &BodyForm,
 ) -> Option<CompileErr> {
+    let mut no_imported_helpers = |_frontend: &CompileForm, _name: &[u8]| false;
+    check_live_helper_calls_with_imports(prims, scopes, frontend, exp, &mut no_imported_helpers)
+}
+
+fn check_live_helper_calls_with_imports<F>(
+    prims: &[Vec<u8>],
+    scopes: &ParseScope,
+    frontend: &CompileForm,
+    exp: &BodyForm,
+    imported_helper_resolver: &mut F,
+) -> Option<CompileErr>
+where
+    F: FnMut(&CompileForm, &[u8]) -> bool,
+{
     match exp {
         BodyForm::Call(l, v, rest_args) => {
             if v.is_empty() {
@@ -498,7 +524,7 @@ pub fn check_live_helper_calls(
 
             // Try to make sense of the list head
             if let BodyForm::Value(s) = v[0].borrow() {
-                if !find_function_in_scopes(prims, scopes, s) {
+                if !find_function_in_scopes(prims, scopes, frontend, s, imported_helper_resolver) {
                     return Some(CompileErr(
                         s.loc(),
                         format!("No such function found: {}", s),
@@ -512,23 +538,47 @@ pub fn check_live_helper_calls(
             }
 
             for b in v.iter().skip(1) {
-                if let Some(e) = check_live_helper_calls(prims, scopes, b) {
+                if let Some(e) = check_live_helper_calls_with_imports(
+                    prims,
+                    scopes,
+                    frontend,
+                    b,
+                    imported_helper_resolver,
+                ) {
                     return Some(e);
                 }
             }
 
             if let Some(tail) = rest_args {
-                if let Some(e) = check_live_helper_calls(prims, scopes, tail) {
+                if let Some(e) = check_live_helper_calls_with_imports(
+                    prims,
+                    scopes,
+                    frontend,
+                    tail,
+                    imported_helper_resolver,
+                ) {
                     return Some(e);
                 }
             }
         }
         BodyForm::Let(_kind, letdata) => {
-            return check_live_helper_calls(prims, scopes, letdata.body.borrow());
+            return check_live_helper_calls_with_imports(
+                prims,
+                scopes,
+                frontend,
+                letdata.body.borrow(),
+                imported_helper_resolver,
+            );
         }
 
         BodyForm::Lambda(ldata) => {
-            return check_live_helper_calls(prims, scopes, ldata.body.borrow());
+            return check_live_helper_calls_with_imports(
+                prims,
+                scopes,
+                frontend,
+                ldata.body.borrow(),
+                imported_helper_resolver,
+            );
         }
 
         _ => {}
@@ -586,6 +636,26 @@ pub fn combine_new_with_old_parse(
     parsed: &ParsedDoc,
     reparse: &ReparsedModule,
 ) -> ParsedDoc {
+    let mut no_imported_helpers = |_frontend: &CompileForm, _name: &[u8]| false;
+    combine_new_with_old_parse_with_imports(
+        uristring,
+        text,
+        parsed,
+        reparse,
+        &mut no_imported_helpers,
+    )
+}
+
+pub fn combine_new_with_old_parse_with_imports<F>(
+    uristring: &str,
+    text: &[Rc<Vec<u8>>],
+    parsed: &ParsedDoc,
+    reparse: &ReparsedModule,
+    imported_helper_resolver: &mut F,
+) -> ParsedDoc
+where
+    F: FnMut(&CompileForm, &[u8]) -> bool,
+{
     let mut new_includes = parsed.includes.clone();
     let mut new_helpers = parsed.helpers.clone();
     let mut extracted_helpers = Vec::new();
@@ -697,16 +767,26 @@ pub fn combine_new_with_old_parse(
 
     for h in compile_with_dead_helpers_removed.helpers.iter() {
         if let HelperForm::Defun(_, d) = h {
-            if let Some(error) = check_live_helper_calls(&PRIM_NAMES, &scopes, &d.body) {
+            if let Some(error) = check_live_helper_calls_with_imports(
+                &PRIM_NAMES,
+                &scopes,
+                &compile_with_dead_helpers_removed,
+                &d.body,
+                imported_helper_resolver,
+            ) {
                 out_errors.push(error);
             }
         }
     }
 
     // Check whether functions called in exp are live
-    if let Some(error) =
-        check_live_helper_calls(&PRIM_NAMES, &scopes, &compile_with_dead_helpers_removed.exp)
-    {
+    if let Some(error) = check_live_helper_calls_with_imports(
+        &PRIM_NAMES,
+        &scopes,
+        &compile_with_dead_helpers_removed,
+        &compile_with_dead_helpers_removed.exp,
+        imported_helper_resolver,
+    ) {
         out_errors.push(error);
     }
 

--- a/wasm/src/lsp/types.rs
+++ b/wasm/src/lsp/types.rs
@@ -27,11 +27,15 @@ use crate::interfaces::{IFileReader, ILogWriter};
 use crate::lsp::compopts::{get_file_content, LSPCompilerOpts};
 use crate::lsp::parse::{make_simple_ranges, IncludedFileSpec, ParsedDoc};
 use crate::lsp::patch::stringify_doc;
-use crate::lsp::reparse::{combine_new_with_old_parse, reparse_subset, ReparsedModule};
+use crate::lsp::reparse::{
+    combine_new_with_old_parse_with_imports, reparse_subset, ReparsedModule,
+};
+use crate::lsp::resolve::HelperResolver;
 use crate::lsp::semtok::SemanticTokenSortable;
 use chialisp::compiler::compiler::DefaultCompilerOpts;
 use chialisp::compiler::comptypes::{
-    BodyForm, CompileErr, CompilerOpts, Export, HelperForm, ImportLongName, LongNameTranslation,
+    BodyForm, CompileErr, CompileForm, CompilerOpts, Export, HelperForm, ImportLongName,
+    LongNameTranslation,
 };
 use chialisp::compiler::prims::prims;
 use chialisp::compiler::sexp::{decode_string, SExp};
@@ -818,7 +822,19 @@ impl LSPServiceProvider {
                 }
             }
 
-            let new_parse = combine_new_with_old_parse(uristring, &doc.text, &output, &new_helpers);
+            let mut resolve_imported_helper = |frontend: &CompileForm, name: &[u8]| {
+                matches!(
+                    self.resolve_helper_reference(frontend, name),
+                    Some(HelperForm::Defun(_, _) | HelperForm::Defmacro(_))
+                )
+            };
+            let new_parse = combine_new_with_old_parse_with_imports(
+                uristring,
+                &doc.text,
+                &output,
+                &new_helpers,
+                &mut resolve_imported_helper,
+            );
 
             self.set_error_list(
                 uristring,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make live-call diagnostics consult the same imported-helper resolver used by semantic tokens/goto definition.
- Preserve the existing pure reparse combine path for callers that do not have an LSP resolver.
- Wire LSP document parsing to resolve imported `defun`/`defmacro` references before reporting `No such function`.

## Root cause
`goto definition` resolved imported helpers through `HelperResolver`, but the live-call diagnostic path only checked local scope functions and CLVM primitives. As a result, imported calls such as `reverse` from `(import std.reverse)` could be marked as missing even when the imported file was found and definition resolution could locate the helper.

## Tests
- `cargo +stable test --locked test_lsp_should_not_get_error -- --nocapture`
- `cargo +stable test --locked`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21347e02-41a8-45a2-9334-098059660ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21347e02-41a8-45a2-9334-098059660ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

