### PR TITLE
Fix debug runner stdin framing

### DIFF
--- a/debug/package.json
+++ b/debug/package.json
@@ -1,7 +1,8 @@
 {
   "name": "chialisp-lsp-runner",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "test": "node --test test/*.test.js"
   },
   "devDependencies": {
     "webpack": "^5.105.2",

--- a/debug/src/runner.js
+++ b/debug/src/runner.js
@@ -78,7 +78,6 @@ function stopStepper() {
 function deliverMessage(m) {
     let messages = [];
     try {
-        processCommand(JSON.parse(m));
         log.write(`input msg ${m}`);
         messages = clvm_tools_rs.dbg_service_handle_msg(dbg_id, m);
     } catch (e) {
@@ -120,7 +119,12 @@ function processCommand(cmd) {
     log.write(JSON.stringify(cmd));
 }
 
-const stdinReader = new StdinReader(deliverMessage);
+function deliverStdinMessage(m) {
+    processCommand(JSON.parse(m));
+    deliverMessage(m);
+}
+
+const stdinReader = new StdinReader(deliverStdinMessage);
 
 process.stdin.on('data', function(chunk) {
     stdinReader.processChunk(log, chunk);

--- a/debug/src/runner.js
+++ b/debug/src/runner.js
@@ -2,15 +2,10 @@ let clvm_tools_rs = require('../build/clvm_tools_lsp');
 let process = require('process');
 let path = require('path');
 let fs = require('fs');
+let {StdinReader} = require('./stdin_reader');
 
 // clean 1:1 8-bit encoding.
 process.stdin.setEncoding('binary');
-
-const START_HEADER = 0;
-const EOL_RETURN = 1;
-const FIRST_EOL = 2;
-const MAYBE_SECOND_EOL = 3;
-const MESSAGE_READ = 4;
 
 var workspaceFolder = process.env.WORKSPACE_FOLDER ? process.env.WORKSPACE_FOLDER : ".";
 
@@ -43,7 +38,6 @@ let dbg_id = clvm_tools_rs.create_dbg_service(function(name) {
 });
 
 var stepper_tick = undefined;
-let stdin_reader = {};
 
 // We don't have threads in wasm so we depend on a ticker at this layer to cause
 // the debugger to auto-step, keeping control coming from one consistent source.
@@ -56,7 +50,7 @@ function startStepper() {
     }
 
     stepper_tick = setInterval(() => {
-        stdin_reader.deliver_msg(JSON.stringify({
+        deliverMessage(JSON.stringify({
             seq:0,
             type:"request",
             command:"stepIn",
@@ -76,18 +70,15 @@ function stopStepper() {
     stepper_tick = undefined;
 }
 
-stdin_reader.mode = START_HEADER;
-stdin_reader.message_header = '';
-stdin_reader.message_payload = '';
-stdin_reader.remaining_bytes = 0;
 // When a full message is captured and parsed, it's delivered here.  The API
 // entry point receives the message in json format.
 //
 // We recognize the debug service indicating that it wants the runner to start
 // automatically stepping and events that cause it to stop.
-stdin_reader.deliver_msg = function(m) {
+function deliverMessage(m) {
     let messages = [];
     try {
+        processCommand(JSON.parse(m));
         log.write(`input msg ${m}`);
         messages = clvm_tools_rs.dbg_service_handle_msg(dbg_id, m);
     } catch (e) {
@@ -110,7 +101,7 @@ stdin_reader.deliver_msg = function(m) {
             process.stdout.write(message);
         }
     }
-};
+}
 
 function processCommand(cmd) {
     log.write(`process command ${JSON.stringify(cmd)}`);
@@ -129,70 +120,10 @@ function processCommand(cmd) {
     log.write(JSON.stringify(cmd));
 }
 
-// Fairly complicated but the goal here is to implement a state machine that
-// parses the http-header-like message protocol used by the debug adapter and
-// lsp.  Ultimately, the goal is to call processCommand 
-process.stdin.on('data', function(chunk) {
-    for (var i = 0; i < chunk.length; ) {
-        let ch = chunk[i];
-        let do_inc = 1;
-        if (stdin_reader.mode === START_HEADER) {
-            if (ch === '\r' || ch === '\n') {
-                let line = stdin_reader.message_header.split(':');
-                stdin_reader.message_header = '';
-                if (line[0].match(/[Cc]ontent-[Ll]ength/) && line.length > 1) {
-                    stdin_reader.remaining_bytes = parseInt(line[1].trim());
-                }
-                if (ch === '\r') {
-                    stdin_reader.mode = EOL_RETURN;
-                } else {
-                    stdin_reader.mode = FIRST_EOL;
-                }
-            } else {
-                stdin_reader.message_header += ch;
-            }
-        } else if (stdin_reader.mode == EOL_RETURN) {
-            if (ch === '\n') {
-                stdin_reader.mode = FIRST_EOL;
-            }
-        } else if (stdin_reader.mode == FIRST_EOL) {
-            if (ch === '\r') {
-                stdin_reader.mode = MAYBE_SECOND_EOL;
-            } else if (ch === '\n') {
-                stdin_reader.mode = MESSAGE_READ;
-            } else {
-                stdin_reader.mode = START_HEADER;
-                stdin_reader.message_header += ch;
-            }
-        } else if (stdin_reader.mode == MAYBE_SECOND_EOL) {
-            if (ch === '\n') {
-                stdin_reader.mode = MESSAGE_READ;
-            }
-        } else { // MESSAGE_READ
-            do_inc = 0;
-            if (chunk.length >= stdin_reader.remaining_bytes) {
-                let message = chunk.substr(i, stdin_reader.remaining_bytes);
-                i += stdin_reader.remaining_bytes;
-                stdin_reader.remaining_bytes = 0;
-                stdin_reader.mode = START_HEADER;
-                try {
-                    if (stdin_reader.deliver_msg) {
-                        processCommand(JSON.parse(message));
-                        stdin_reader.deliver_msg(message);
-                    }
-                } catch (e) {
-                    log.write('exception ' + e);
-                }
-            } else {
-                stdin_reader.message_payload += chunk.substr(i);
-                let can_use_bytes = chunk.length - i;
-                stdin_reader.remaining_bytes -= can_use_bytes;
-                i += can_use_bytes; // end
-            }
-        }
+const stdinReader = new StdinReader(deliverMessage);
 
-        i += do_inc;
-    }
+process.stdin.on('data', function(chunk) {
+    stdinReader.processChunk(log, chunk);
 });
 
 process.stdin.on('end', function() {

--- a/debug/src/stdin_reader.js
+++ b/debug/src/stdin_reader.js
@@ -1,0 +1,82 @@
+const START_HEADER = 0;
+const EOL_RETURN = 1;
+const FIRST_EOL = 2;
+const MAYBE_SECOND_EOL = 3;
+const MESSAGE_READ = 4;
+
+class StdinReader {
+    constructor(deliverMsg) {
+        this.mode = START_HEADER;
+        this.messageHeader = '';
+        this.messagePayload = '';
+        this.remainingBytes = 0;
+        this.deliverMsg = deliverMsg;
+    }
+
+    // Process a DAP/LSP-style Content-Length stream. Chunks can split headers,
+    // payloads, or contain multiple messages.
+    processChunk(log, chunk) {
+        for (let i = 0; i < chunk.length; ) {
+            let ch = chunk[i];
+            let doInc = 1;
+            if (this.mode === START_HEADER) {
+                if (ch === '\r' || ch === '\n') {
+                    let line = this.messageHeader.split(':');
+                    this.messageHeader = '';
+                    if (line[0].match(/[Cc]ontent-[Ll]ength/) && line.length > 1) {
+                        this.remainingBytes = parseInt(line[1].trim());
+                    }
+                    if (ch === '\r') {
+                        this.mode = EOL_RETURN;
+                    } else {
+                        this.mode = FIRST_EOL;
+                    }
+                } else {
+                    this.messageHeader += ch;
+                }
+            } else if (this.mode === EOL_RETURN) {
+                if (ch === '\n') {
+                    this.mode = FIRST_EOL;
+                }
+            } else if (this.mode === FIRST_EOL) {
+                if (ch === '\r') {
+                    this.mode = MAYBE_SECOND_EOL;
+                } else if (ch === '\n') {
+                    this.mode = MESSAGE_READ;
+                } else {
+                    this.mode = START_HEADER;
+                    this.messageHeader += ch;
+                }
+            } else if (this.mode === MAYBE_SECOND_EOL) {
+                if (ch === '\n') {
+                    this.mode = MESSAGE_READ;
+                }
+            } else {
+                doInc = 0;
+                if (chunk.length - i >= this.remainingBytes) {
+                    let message = this.messagePayload + chunk.substr(i, this.remainingBytes);
+                    this.messagePayload = '';
+                    i += this.remainingBytes;
+                    this.remainingBytes = 0;
+                    this.mode = START_HEADER;
+                    try {
+                        if (this.deliverMsg) {
+                            this.deliverMsg(message);
+                        }
+                    } catch (e) {
+                        log.write('exception ' + e);
+                    }
+                } else {
+                    this.messagePayload += chunk.substr(i);
+                    let canUseBytes = chunk.length - i;
+                    this.remainingBytes -= canUseBytes;
+                    i += canUseBytes;
+                }
+            }
+
+            i += doInc;
+        }
+    }
+}
+
+module.exports = {StdinReader};

--- a/debug/test/stdin_reader.test.js
+++ b/debug/test/stdin_reader.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const test = require('node:test');
+const {StdinReader} = require('../src/stdin_reader');
+
+const log = {write: () => {}};
+
+function packet(payload) {
+    return `Content-Length: ${Buffer.byteLength(payload, 'utf8')}\r\n\r\n${payload}`;
+}
+
+test('parses fragmented messages', () => {
+    let received = 0;
+    const reader = new StdinReader((message) => {
+        const parsed = JSON.parse(message);
+        assert.equal(parsed.test, received);
+        received += 1;
+    });
+
+    reader.processChunk(log, packet('{"test":0}'));
+    reader.processChunk(log, 'Content-Length: 10\r\n\r\n{"');
+    reader.processChunk(log, 'test":1}Content-Length: 10\r\n\r\n{');
+    reader.processChunk(log, '"test":2}');
+
+    assert.equal(received, 3);
+});
+
+test('combines accumulated payload before delivery', () => {
+    const messages = [];
+    const reader = new StdinReader((message) => {
+        messages.push(message);
+    });
+
+    const message = '{"command":"stepIn","arguments":{"threadId":1}}';
+    const stream = packet(message);
+    const payloadStart = stream.indexOf('\r\n\r\n') + 4;
+
+    reader.processChunk(log, stream.slice(0, payloadStart + 7));
+    reader.processChunk(log, stream.slice(payloadStart + 7));
+
+    assert.deepEqual(messages, [message]);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a testable stdin reader for the debug runner's DAP Content-Length stream
- Preserve partial payloads across chunks before delivering messages
- Keep stdin-only command processing out of internal auto-step delivery so continuous `stepIn` ticks do not run `processCommand`/stderr logging

## Testing
- `cd debug && npm test` ✅
- `cd debug && npm ci && npm run build` ⚠️ dependencies install and webpack reaches `src/runner.js`, but build remains blocked because generated wasm artifacts are absent (`debug/build/clvm_tools_lsp.js` missing)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fc729a3-e6ae-482d-8925-2db8cc808806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fc729a3-e6ae-482d-8925-2db8cc808806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

