### PR TITLE
Ensure we don't miss this serialize-javascript upgrade

### DIFF
--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -3375,7 +3375,7 @@
         "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.6",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^9.2.0",
@@ -3499,15 +3499,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -3907,15 +3898,6 @@
       "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
       "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/react-is": {
       "version": "18.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,6 +10,7 @@
     "serialize-javascript": "^7.0.6"
   },
   "resolutions": {
-    "diff": "^9.0.0"
+    "diff": "^9.0.0",
+    "serialize-javascript": "^7.0.6"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only dependency and lockfile changes with no application runtime impact.
> 
> **Overview**
> Pins **`serialize-javascript`** to **^7.0.6** in the `test` package so the upgrade is not lost to transitive resolution.
> 
> Adds it as a **direct dependency** and a **`resolutions`** entry (same pattern as `diff`). The lockfile moves Mocha’s `serialize-javascript` from **6.0.2** to **7.0.6** and drops the nested **6.x** copy and its **`randombytes`** dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79ee052ab788dede11354844b352a3b66bc8dfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->