### PR TITLE
Publish with oidc

### DIFF
--- a/.github/workflows/nightly-dev.yml
+++ b/.github/workflows/nightly-dev.yml
@@ -101,6 +101,7 @@ jobs:
           fi
 
       - name: Azure login (user-assigned managed identity)
+        if: env.SKIP != 'true'
         uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}

--- a/.github/workflows/nightly-dev.yml
+++ b/.github/workflows/nightly-dev.yml
@@ -5,23 +5,30 @@ on:
     - cron: '0 0 * * *' # This will run the workflow every day at midnight
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
-
+    environment: vscode-marketplace
     steps:
       - name: Check out code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: 'dev'
+
       - name: Set Job Env
         uses: Chia-Network/actions/setjobenv@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -29,15 +36,19 @@ jobs:
             target: wasm32-unknown-unknown
             override: true
             components: rustfmt
+
       - name: Install wasm-pack
         run: |
           sh install-clvm_tools_rs.sh
           cargo install --version 0.13.1 wasm-pack
+
       - name: Install
         run: npm ci
+
       - name: Check for published package
         run: |
           ./node_modules/.bin/vsce show "ChiaNetwork.chialisp-dev" --json | jq -r '.extensionName' || echo "VSIX_EXISTS=false" >> "$GITHUB_ENV"
+
       - name: Check for changes
         if: env.VSIX_EXISTS != 'false'
         id: check_changes
@@ -50,9 +61,11 @@ jobs:
           else
             echo "SKIP=false" >> "$GITHUB_ENV"
           fi
+
       - name: Compile & lint
         if: env.SKIP != 'true'
         run: npm run pretest
+
       - name: Build dev extension
         if: env.SKIP != 'true'
         id: package_name
@@ -62,9 +75,11 @@ jobs:
           fi
           ./node_modules/.bin/vsce package --no-yarn
           echo "VSIX_FILE=$(ls -- *.vsix)" >> "$GITHUB_OUTPUT"
+
       - name: Fix dates
         run: |
           python datefix.py *.vsix
+
       - name: Run headless test
         if: env.SKIP != 'true'
         env:
@@ -73,6 +88,7 @@ jobs:
           sudo apt update
           sudo apt-get install -qy xvfb libnss3-dev libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm-dev libasound2t64
           xvfb-run -a ./test/test.sh
+
       - name: Cleanup xvfb pidx
         if: env.SKIP != 'true'
         run: |
@@ -83,10 +99,18 @@ jobs:
           else
               echo "No xvfb processes to kill"
           fi
+
+      - name: Azure login (user-assigned managed identity)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+          enable-AzPSSession: true
+
       - name: Publish chialisp-dev to Visual Studio Marketplace
         if: env.SKIP != 'true'
         env:
-          VSCE_PAT: ${{ secrets.MARKETPLACE_PAT }}
           VSIX_FILE: ${{ steps.package_name.outputs.VSIX_FILE }}
         run: |
           # Find files with timestamps in the future
@@ -95,4 +119,4 @@ jobs:
           for file in $future_files; do
             touch -a -m -t $(date -d "now - 1 minute" +'%Y%m%d%H%M.%S') "$file"
           done
-          ./node_modules/.bin/vsce publish --no-yarn -i "$GITHUB_WORKSPACE"/"$VSIX_FILE"
+          ./node_modules/.bin/vsce publish --azure-credential --no-yarn -i "$GITHUB_WORKSPACE"/"$VSIX_FILE"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,7 @@ jobs:
           fi
 
       - name: Azure login (user-assigned managed identity)
+        if: env.PRE_RELEASE == 'true' || env.FULL_RELEASE == 'true'
         uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,48 +1,62 @@
+name: Deploy Extension
 
 on:
   workflow_dispatch:
   release:
     types: [published]
 
-name: Deploy Extension
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: vscode-marketplace
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
+
       - name: Set Job Env
         uses: Chia-Network/actions/setjobenv@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
+
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@stable
         with:
             target: wasm32-unknown-unknown
             components: rustfmt
+
       - name: Install wasm-pack
         run: |
           cargo install --version 0.13.1 wasm-pack
+
       - name: Install
         run: npm ci
+
       - name: Compile & lint
         run: npm run pretest
+
       - name: Build pre-release extension
         id: package_name_pre
         if: env.PRE_RELEASE == 'true'
         run: |
           ./node_modules/.bin/vsce package --pre-release --no-yarn
           echo "VSIX_FILE=$(ls -- *.vsix)" >>$GITHUB_OUTPUT
+
       - name: Build release extension
         id: package_name
         if: env.FULL_RELEASE == 'true'
         run: |
           ./node_modules/.bin/vsce package --no-yarn
           echo "VSIX_FILE=$(ls -- *.vsix)" >>$GITHUB_OUTPUT
+
       - name: Run headless test
         run: |
           sudo apt update
@@ -58,15 +72,23 @@ jobs:
           else
               echo "No xvfb processes to kill"
           fi
+
+      - name: Azure login (user-assigned managed identity)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+          enable-AzPSSession: true
+
       - name: Publish Pre-release to Visual Studio Marketplace
         if: env.PRE_RELEASE == 'true'
         env:
-          VSCE_PAT: ${{ secrets.MARKETPLACE_PAT }}
           VSIX_FILE: ${{ steps.package_name_pre.outputs.VSIX_FILE }}
-        run: ./node_modules/.bin/vsce publish --pre-release --no-yarn -i "$GITHUB_WORKSPACE"/"$VSIX_FILE"
+        run: ./node_modules/.bin/vsce publish --azure-credential --pre-release --no-yarn -i "$GITHUB_WORKSPACE"/"$VSIX_FILE"
+
       - name: Publish Release to Visual Studio Marketplace
         if: env.FULL_RELEASE == 'true'
         env:
-          VSCE_PAT: ${{ secrets.MARKETPLACE_PAT }}
           VSIX_FILE: ${{ steps.package_name.outputs.VSIX_FILE }}
-        run: ./node_modules/.bin/vsce publish --no-yarn -i "$GITHUB_WORKSPACE"/"$VSIX_FILE"
+        run: ./node_modules/.bin/vsce publish --azure-credential --no-yarn -i "$GITHUB_WORKSPACE"/"$VSIX_FILE"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Publishing is security-sensitive; a misconfigured Azure identity or GitHub environment could block releases or widen who can publish until OIDC trust is correct.
> 
> **Overview**
> **Switches Visual Studio Marketplace publishing from a stored PAT to OIDC via Azure.**
> 
> Both `nightly-dev.yml` and `publish.yml` now grant `id-token: write`, run the publish job in the `vscode-marketplace` GitHub environment, and add an **Azure login** step (`azure/login@v3`) using repo variables `AZURE_CLIENT_ID` and `AZURE_TENANT_ID`. `vsce publish` is updated to use `--azure-credential` and no longer sets `VSCE_PAT` / `secrets.MARKETPLACE_PAT`.
> 
> Minor workflow tweaks include pinning `actions/checkout@v7` (from `v7.0.0`) and giving `publish.yml` an explicit workflow name `Deploy Extension`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c0272b2ba2e7b52bfffd5e5b2a6c5f3b3e930c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->